### PR TITLE
Add two structural witin types to support double range check

### DIFF
--- a/crates/multilinear_extensions/src/expression.rs
+++ b/crates/multilinear_extensions/src/expression.rs
@@ -1032,6 +1032,14 @@ pub enum StructuralWitInType {
     /// The corresponding evaluation vector is the sequence: [0, 0] + [1, 1] + [2] * 4 + [3] * 8 + ... + [max_value] * (2^max_value)
     /// The length of the vectors is 2^(max_value + 1)
     StackedConstantSequence { max_value: usize },
+    /// The corresponding evaluation vector is the sequence: [0, ..., 0, 1, ..., 1, ..., 2^(n-k-1)-1, ..., 2^(n-k-1)-1]
+    /// where each element is repeated by 2^k times
+    /// The total length of the vector is 2^n
+    InnerRepeatingIncrementalSequence { k: usize, n: usize },
+    /// The corresponding evaluation vector is the sequence: [0, ..., 2^k-1]
+    /// repeated by 2^(n-k) times
+    /// The total length of the vector is 2^n
+    OuterRepeatingIncrementalSequence { k: usize, n: usize },
 }
 
 impl StructuralWitInType {
@@ -1040,6 +1048,8 @@ impl StructuralWitInType {
             StructuralWitInType::EqualDistanceSequence { max_len, .. } => *max_len,
             StructuralWitInType::StackedIncrementalSequence { max_bits } => 1 << (max_bits + 1),
             StructuralWitInType::StackedConstantSequence { max_value } => 1 << (max_value + 1),
+            StructuralWitInType::InnerRepeatingIncrementalSequence { n, .. } => 1 << n,
+            StructuralWitInType::OuterRepeatingIncrementalSequence { n, .. } => 1 << n,
         }
     }
 }


### PR DESCRIPTION
Need to merge this before this [PR](https://github.com/scroll-tech/ceno/pull/1044) can work.