### PR TITLE
Chore: bump up plonky3 dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -653,7 +653,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "num-bigint",
  "p3-dft",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "rayon",
 ]
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-dft",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "gcd",
  "p3-field",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=539bbc8#539bbc84085efb609f4f62cb03cf49588388abdb"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,21 +39,21 @@ clap = { version = "4.5", features = ["derive"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 either = { version = "1.15.*", features = ["serde"] }
 itertools = "0.13"
-p3-baby-bear = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-challenger = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-commit = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-dft = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-field = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-fri = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-goldilocks = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-matrix = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-mds = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-merkle-tree = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-poseidon = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-poseidon2 = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-symmetric = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
-p3-util = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-baby-bear = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-challenger = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-commit = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-dft = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-field = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-fri = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-goldilocks = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-matrix = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-mds = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-poseidon = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-symmetric = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
+p3-util = { git = "https://github.com/Plonky3/plonky3", rev = "539bbc8" }
 rand = "0.8"
 rand_chacha = { version = "0.3", features = ["serde1"] }
 rand_core = "0.6"


### PR DESCRIPTION
# Summary

Bump the `p3-*` dependencies to `539bbc8` which is the version required by our recursion backend (i.e. [OpenVM](https://github.com/openvm-org/openvm/blob/v1.3.0/Cargo.toml#L173-L185))