### PR TITLE
feat(sumcheck): build `h1(x)` without fix mles at `r0` from first round

### DIFF
--- a/crates/multilinear_extensions/src/mle.rs
+++ b/crates/multilinear_extensions/src/mle.rs
@@ -567,6 +567,76 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         self.num_vars = nv - partial_point.len();
     }
 
+    /// Reduce the number of variables by 2 in one pass.
+    ///
+    /// This avoids calling `fix_variables` twice and directly computes
+    /// `f(r0, r1, ..)` from 4-point blocks.
+    pub fn fix_two_variables(&self, r0: E, r1: E) -> Self {
+        assert!(self.num_vars() >= 2, "num_vars {} < 2", self.num_vars());
+        let nv = self.num_vars();
+        match self.evaluations() {
+            FieldType::Base(slice) => MultilinearExtension::from_evaluations_ext_vec(
+                nv - 2,
+                slice
+                    .chunks(4)
+                    .map(|buf| {
+                        let y0 = r0 * (buf[1] - buf[0]) + buf[0];
+                        let y1 = r0 * (buf[3] - buf[2]) + buf[2];
+                        y0 + (y1 - y0) * r1
+                    })
+                    .collect(),
+            ),
+            FieldType::Ext(slice) => MultilinearExtension::from_evaluations_ext_vec(
+                nv - 2,
+                slice
+                    .chunks(4)
+                    .map(|buf| {
+                        let y0 = buf[0] + (buf[1] - buf[0]) * r0;
+                        let y1 = buf[2] + (buf[3] - buf[2]) * r0;
+                        y0 + (y1 - y0) * r1
+                    })
+                    .collect(),
+            ),
+            FieldType::Unreachable => unreachable!(),
+        }
+    }
+
+    /// In-place variant of `fix_two_variables`.
+    pub fn fix_two_variables_in_place(&mut self, r0: E, r1: E) {
+        assert!(self.is_mut());
+        assert!(self.num_vars() >= 2, "num_vars {} < 2", self.num_vars());
+        let nv = self.num_vars();
+
+        match &mut self.evaluations {
+            FieldType::Base(slice) => {
+                let slice_ext = slice
+                    .chunks(4)
+                    .map(|buf| {
+                        let y0 = r0 * (buf[1] - buf[0]) + buf[0];
+                        let y1 = r0 * (buf[3] - buf[2]) + buf[2];
+                        y0 + (y1 - y0) * r1
+                    })
+                    .collect();
+                let _ = mem::replace(
+                    &mut self.evaluations,
+                    FieldType::Ext(SmartSlice::Owned(slice_ext)),
+                );
+            }
+            FieldType::Ext(slice) => {
+                let slice_mut = slice.to_mut();
+                (0..slice_mut.len()).step_by(4).for_each(|b| {
+                    let y0 = slice_mut[b] + (slice_mut[b + 1] - slice_mut[b]) * r0;
+                    let y1 = slice_mut[b + 2] + (slice_mut[b + 3] - slice_mut[b + 2]) * r0;
+                    slice_mut[b >> 2] = y0 + (y1 - y0) * r1;
+                });
+                slice.truncate_mut(1 << (nv - 2));
+            }
+            FieldType::Unreachable => unreachable!(),
+        }
+
+        self.num_vars = nv - 2;
+    }
+
     /// Evaluate the MLE at a give point.
     /// Returns an error if the MLE length does not match the point.
     pub fn evaluate(&self, point: &[E]) -> E {

--- a/crates/multilinear_extensions/src/mle.rs
+++ b/crates/multilinear_extensions/src/mle.rs
@@ -1,4 +1,4 @@
-use std::{any::TypeId, borrow::Cow, mem, sync::Arc};
+use std::{any::TypeId, borrow::Cow, mem, ops::Range, sync::Arc};
 
 use crate::{
     field_type_mut_map,
@@ -228,6 +228,14 @@ impl<'a, E: ExtensionField> FieldType<'a, E> {
         match self {
             FieldType::Base(slice) => Either::Left(slice[index]),
             FieldType::Ext(slice) => Either::Right(slice[index]),
+            FieldType::Unreachable => unreachable!(),
+        }
+    }
+
+    pub fn as_slice(&self, range: Range<usize>) -> Either<&[E::BaseField], &[E]> {
+        match self {
+            FieldType::Base(slice) => Either::Left(&slice[range]),
+            FieldType::Ext(slice) => Either::Right(&slice[range]),
             FieldType::Unreachable => unreachable!(),
         }
     }
@@ -567,6 +575,27 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         self.num_vars = nv - partial_point.len();
     }
 
+    // compute f(r0,r1,b) from block { f(0,0,b), f(1,0,b), f(0,1,b), f(1,1,b) }
+    #[inline(always)]
+    fn eval_block_2_vars_base(block: &[E::BaseField], r0: E, r1: E) -> E {
+        // f(r0,r1,b) = (1 - r1) * f(r0,0,b) + r1 * f(r0,1,b)
+        // f(r0,0,b) = (1 - r0) * f(0,0,b) + r0 * f(1,0,b)
+        // f(r0,1,b) = (1 - r0) * f(0,1,b) + r0 * f(1,1,b)
+        let y0: E = r0 * (block[1] - block[0]) + block[0];
+        let y1: E = r0 * (block[3] - block[2]) + block[2];
+        y0 + (y1 - y0) * r1
+    }
+
+    #[inline(always)]
+    fn eval_block_2_vars_ext(block: &[E], r0: E, r1: E) -> E {
+        // f(r0,r1,b) = (1 - r1) * f(r0,0,b) + r1 * f(r0,1,b)
+        // f(r0,0,b) = (1 - r0) * f(0,0,b) + r0 * f(1,0,b)
+        // f(r0,1,b) = (1 - r0) * f(0,1,b) + r0 * f(1,1,b)
+        let y0: E = block[0] + (block[1] - block[0]) * r0;
+        let y1: E = block[2] + (block[3] - block[2]) * r0;
+        y0 + (y1 - y0) * r1
+    }
+
     /// Reduce the number of variables by 2 in one pass.
     ///
     /// This avoids calling `fix_variables` twice and directly computes
@@ -579,22 +608,14 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
                 nv - 2,
                 slice
                     .chunks(4)
-                    .map(|buf| {
-                        let y0 = r0 * (buf[1] - buf[0]) + buf[0];
-                        let y1 = r0 * (buf[3] - buf[2]) + buf[2];
-                        y0 + (y1 - y0) * r1
-                    })
+                    .map(|buf| Self::eval_block_2_vars_base(buf, r0, r1))
                     .collect(),
             ),
             FieldType::Ext(slice) => MultilinearExtension::from_evaluations_ext_vec(
                 nv - 2,
                 slice
                     .chunks(4)
-                    .map(|buf| {
-                        let y0 = buf[0] + (buf[1] - buf[0]) * r0;
-                        let y1 = buf[2] + (buf[3] - buf[2]) * r0;
-                        y0 + (y1 - y0) * r1
-                    })
+                    .map(|buf| Self::eval_block_2_vars_ext(buf, r0, r1))
                     .collect(),
             ),
             FieldType::Unreachable => unreachable!(),
@@ -609,27 +630,23 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
 
         match &mut self.evaluations {
             FieldType::Base(slice) => {
-                let slice_ext = slice
+                let ext_vec = slice
                     .chunks(4)
-                    .map(|buf| {
-                        let y0 = r0 * (buf[1] - buf[0]) + buf[0];
-                        let y1 = r0 * (buf[3] - buf[2]) + buf[2];
-                        y0 + (y1 - y0) * r1
-                    })
+                    .map(|buf| Self::eval_block_2_vars_base(buf, r0, r1))
                     .collect();
-                let _ = mem::replace(
+                let _ = std::mem::replace(
                     &mut self.evaluations,
-                    FieldType::Ext(SmartSlice::Owned(slice_ext)),
+                    FieldType::Ext(SmartSlice::Owned(ext_vec)),
                 );
             }
             FieldType::Ext(slice) => {
                 let slice_mut = slice.to_mut();
-                (0..slice_mut.len()).step_by(4).for_each(|b| {
-                    let y0 = slice_mut[b] + (slice_mut[b + 1] - slice_mut[b]) * r0;
-                    let y1 = slice_mut[b + 2] + (slice_mut[b + 3] - slice_mut[b + 2]) * r0;
-                    slice_mut[b >> 2] = y0 + (y1 - y0) * r1;
-                });
-                slice.truncate_mut(1 << (nv - 2));
+                let new_len = 1 << (nv - 2);
+                for i in 0..new_len {
+                    let b = i << 2;
+                    slice_mut[i] = Self::eval_block_2_vars_ext(&slice_mut[b..b + 4], r0, r1);
+                }
+                slice.truncate_mut(new_len);
             }
             FieldType::Unreachable => unreachable!(),
         }

--- a/crates/sumcheck/Cargo.toml
+++ b/crates/sumcheck/Cargo.toml
@@ -31,6 +31,7 @@ rand.workspace = true
 [features]
 nightly-features = ["ff_ext/nightly-features"]
 parallel = ["p3/parallel", "multilinear_extensions/parallel"]
+reduce-peak-memory = []
 
 
 [[bench]]

--- a/crates/sumcheck/Cargo.toml
+++ b/crates/sumcheck/Cargo.toml
@@ -36,3 +36,7 @@ parallel = ["p3/parallel", "multilinear_extensions/parallel"]
 [[bench]]
 harness = false
 name = "devirgo_sumcheck"
+
+[[bench]]
+harness = false
+name = "memory_usage"

--- a/crates/sumcheck/benches/devirgo_sumcheck.rs
+++ b/crates/sumcheck/benches/devirgo_sumcheck.rs
@@ -9,7 +9,7 @@ use ff_ext::{ExtensionField, GoldilocksExt2};
 use itertools::Itertools;
 use p3::field::FieldAlgebra;
 use rand::thread_rng;
-use sumcheck::structs::IOPProverState;
+use sumcheck::structs::{IOPProverState, SumcheckProverMode};
 
 use multilinear_extensions::{
     mle::MultilinearExtension, monomial::Term, op_mle, util::max_usable_threads,
@@ -17,7 +17,12 @@ use multilinear_extensions::{
 };
 use transcript::BasicTranscript as Transcript;
 
-criterion_group!(benches, sumcheck_fn, devirgo_sumcheck_fn,);
+criterion_group!(
+    benches,
+    sumcheck_fn,
+    devirgo_sumcheck_fn,
+    devirgo_sumcheck_reduced_peak_memory_fn,
+);
 criterion_main!(benches);
 
 const NUM_SAMPLES: usize = 10;
@@ -214,6 +219,141 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                             IOPProverState::<E>::prove(virtual_poly_v2, &mut prover_transcript);
                         let elapsed = instant.elapsed();
                         time += elapsed;
+                    }
+                    time
+                });
+            },
+        );
+
+        group.finish();
+    }
+}
+
+fn devirgo_sumcheck_reduced_peak_memory_fn(c: &mut Criterion) {
+    type E = GoldilocksExt2;
+
+    let threads = max_usable_threads();
+    for nv in NV {
+        let mut group = c.benchmark_group(format!("devirgo_reduced_peak_memory_nv_{}", nv));
+        group.sample_size(NUM_SAMPLES);
+
+        group.bench_function(
+            BenchmarkId::new(
+                "prove_sumcheck",
+                format!("devirgo_reduced_peak_memory_nv_{}", nv),
+            ),
+            |b| {
+                b.iter_custom(|iters| {
+                    let mut time = Duration::new(0, 0);
+                    for _ in 0..iters {
+                        let mut prover_transcript = Transcript::new(b"test");
+                        let (_, fs) = { prepare_input(nv) };
+
+                        let virtual_poly = VirtualPolynomials::new_from_monimials(
+                            threads,
+                            nv,
+                            vec![Term {
+                                scalar: Either::Right(E::ONE),
+                                product: fs.iter().map(Either::Left).collect_vec(),
+                            }],
+                        );
+                        let instant = std::time::Instant::now();
+                        let _ = IOPProverState::<E>::prove_with_mode(
+                            virtual_poly,
+                            &mut prover_transcript,
+                            SumcheckProverMode::ReducedPeakMemory,
+                        );
+                        time += instant.elapsed();
+                    }
+                    time
+                });
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new(
+                "prove_sumcheck_ext",
+                format!("devirgo_reduced_peak_memory_nv_{}", nv),
+            ),
+            |b| {
+                b.iter_custom(|iters| {
+                    let mut time = Duration::new(0, 0);
+                    for _ in 0..iters {
+                        let mut prover_transcript = Transcript::new(b"test");
+                        let (_, fs) = { prepare_input(nv) };
+                        let fs = fs
+                            .into_iter()
+                            .map(|mle: MultilinearExtension<'_, E>| {
+                                MultilinearExtension::from_evaluation_vec_smart(
+                                    mle.num_vars(),
+                                    mle.get_base_field_vec()
+                                        .iter()
+                                        .map(E::from_ref_base)
+                                        .collect_vec(),
+                                )
+                            })
+                            .collect_vec();
+
+                        let virtual_poly = VirtualPolynomials::new_from_monimials(
+                            threads,
+                            nv,
+                            vec![Term {
+                                scalar: Either::Right(E::ONE),
+                                product: fs.iter().map(Either::Left).collect_vec(),
+                            }],
+                        );
+                        let instant = std::time::Instant::now();
+                        let _ = IOPProverState::<E>::prove_with_mode(
+                            virtual_poly,
+                            &mut prover_transcript,
+                            SumcheckProverMode::ReducedPeakMemory,
+                        );
+                        time += instant.elapsed();
+                    }
+                    time
+                });
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new(
+                "prove_sumcheck_ext_in_place",
+                format!("devirgo_reduced_peak_memory_nv_{}", nv),
+            ),
+            |b| {
+                b.iter_custom(|iters| {
+                    let mut time = Duration::new(0, 0);
+                    for _ in 0..iters {
+                        let mut prover_transcript = Transcript::new(b"test");
+                        let (_, fs) = { prepare_input(nv) };
+                        let mut fs = fs
+                            .into_iter()
+                            .map(|mle: MultilinearExtension<'_, E>| {
+                                MultilinearExtension::from_evaluation_vec_smart(
+                                    mle.num_vars(),
+                                    mle.get_base_field_vec()
+                                        .iter()
+                                        .map(E::from_ref_base)
+                                        .collect_vec(),
+                                )
+                            })
+                            .collect_vec();
+
+                        let virtual_poly = VirtualPolynomials::new_from_monimials(
+                            threads,
+                            nv,
+                            vec![Term {
+                                scalar: Either::Right(E::ONE),
+                                product: fs.iter_mut().map(Either::Right).collect_vec(),
+                            }],
+                        );
+                        let instant = std::time::Instant::now();
+                        let _ = IOPProverState::<E>::prove_with_mode(
+                            virtual_poly,
+                            &mut prover_transcript,
+                            SumcheckProverMode::ReducedPeakMemory,
+                        );
+                        time += instant.elapsed();
                     }
                     time
                 });

--- a/crates/sumcheck/benches/memory_usage.rs
+++ b/crates/sumcheck/benches/memory_usage.rs
@@ -1,8 +1,10 @@
 #![allow(clippy::manual_memcpy)]
 #![allow(clippy::needless_range_loop)]
 
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use either::Either;
 use ff_ext::{BabyBearExt4, ExtensionField};
@@ -128,11 +130,8 @@ fn main() {
                         }],
                     );
 
-                    let _ = IOPProverState::<E>::prove_with_mode(
-                        virtual_poly,
-                        &mut transcript,
-                        mode,
-                    );
+                    let _ =
+                        IOPProverState::<E>::prove_with_mode(virtual_poly, &mut transcript, mode);
                 });
 
                 peaks.push(peak);

--- a/crates/sumcheck/benches/memory_usage.rs
+++ b/crates/sumcheck/benches/memory_usage.rs
@@ -1,0 +1,163 @@
+#![allow(clippy::manual_memcpy)]
+#![allow(clippy::needless_range_loop)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use either::Either;
+use ff_ext::{BabyBearExt4, ExtensionField};
+use itertools::Itertools;
+use multilinear_extensions::{
+    mle::MultilinearExtension, monomial::Term, util::max_usable_threads,
+    virtual_polys::VirtualPolynomials,
+};
+use p3::field::FieldAlgebra;
+use rand::thread_rng;
+use sumcheck::structs::{IOPProverState, SumcheckProverMode};
+use transcript::BasicTranscript as Transcript;
+
+// ---------------------------------------------------------------------------
+// Tracking allocator
+// ---------------------------------------------------------------------------
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct TrackingAllocator;
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            let prev = ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+            let new_total = prev + layout.size();
+            let mut peak = PEAK.load(Ordering::Relaxed);
+            while new_total > peak {
+                match PEAK.compare_exchange_weak(
+                    peak,
+                    new_total,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(p) => peak = p,
+                }
+            }
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        ALLOCATED.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAllocator = TrackingAllocator;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Reset the peak counter to the current live allocation level, then run `f`,
+/// and return the highest additional bytes allocated above that baseline.
+fn measure_peak<F: FnOnce()>(f: F) -> usize {
+    let baseline = ALLOCATED.load(Ordering::SeqCst);
+    PEAK.store(baseline, Ordering::SeqCst);
+    f();
+    PEAK.load(Ordering::SeqCst).saturating_sub(baseline)
+}
+
+fn mb(bytes: usize) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+const NUM_DEGREE: usize = 3;
+
+// s = \prod_i fi
+fn prepare_input<'a, E: ExtensionField>(nv: usize) -> Vec<MultilinearExtension<'a, E>> {
+    let mut rng = thread_rng();
+    (0..NUM_DEGREE)
+        .map(|_| MultilinearExtension::<E>::random(nv, &mut rng))
+        .collect_vec()
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+fn main() {
+    type E = BabyBearExt4;
+
+    let threads = max_usable_threads();
+
+    // Warm up the rayon thread pool so its internal allocations don't skew results.
+    let _ = rayon::current_num_threads();
+
+    const NV: &[usize] = &[25, 26];
+    const RUNS: usize = 3;
+
+    println!(
+        "{:<8} {:<30} {:>12} {:>12} {:>12}",
+        "nv", "mode", "min (MB)", "max (MB)", "median (MB)"
+    );
+    println!("{}", "-".repeat(80));
+
+    for &nv in NV {
+        for mode in [
+            SumcheckProverMode::LegacyStable,
+            SumcheckProverMode::ReducedPeakMemory,
+        ] {
+            let mut peaks: Vec<usize> = Vec::with_capacity(RUNS);
+
+            for _ in 0..RUNS {
+                // Prepare inputs outside the measurement window.
+                let fs = prepare_input::<E>(nv);
+
+                let peak = measure_peak(|| {
+                    let mut transcript = Transcript::new(b"memory-bench");
+
+                    // prove the sumcheck for s = \sum_b \prod_i fi(b)
+                    let virtual_poly = VirtualPolynomials::new_from_monimials(
+                        threads,
+                        nv,
+                        vec![Term {
+                            scalar: Either::Right(E::ONE),
+                            product: fs.iter().map(Either::Left).collect_vec(),
+                        }],
+                    );
+
+                    let _ = IOPProverState::<E>::prove_with_mode(
+                        virtual_poly,
+                        &mut transcript,
+                        mode,
+                    );
+                });
+
+                peaks.push(peak);
+            }
+
+            peaks.sort_unstable();
+            let min = peaks[0];
+            let max = *peaks.last().unwrap();
+            let median = peaks[RUNS / 2];
+
+            let mode_name = match mode {
+                SumcheckProverMode::LegacyStable => "LegacyStable",
+                SumcheckProverMode::ReducedPeakMemory => "ReducedPeakMemory",
+            };
+
+            println!(
+                "{:<8} {:<30} {:>12.1} {:>12.1} {:>12.1}",
+                nv,
+                mode_name,
+                mb(min),
+                mb(max),
+                mb(median),
+            );
+        }
+
+        println!();
+    }
+}

--- a/crates/sumcheck/src/prover.rs
+++ b/crates/sumcheck/src/prover.rs
@@ -206,8 +206,14 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             }
             let span = entered_span!("merged_poly", profiling_6 = true);
             let poly = merge_sumcheck_prover_state(&prover_states);
-            let mut phase2_sumcheck_state =
-                Self::prover_init_with_extrapolation_aux_with_mode(true, poly, None, None, mode);
+            // phase 2 always use legacy mode
+            let mut phase2_sumcheck_state = Self::prover_init_with_extrapolation_aux_with_mode(
+                true,
+                poly,
+                None,
+                None,
+                SumcheckProverMode::LegacyStable,
+            );
             phase2_sumcheck_state.push_challenges(prover_states[0].challenges.clone());
             exit_span!(span);
             (phase2_sumcheck_state, prover_msgs)

--- a/crates/sumcheck/src/prover.rs
+++ b/crates/sumcheck/src/prover.rs
@@ -294,6 +294,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             // This accounts for multiple phases and potential continuation challenges,
             // ensuring we avoid reallocations when the protocol spans multiple rounds
             challenges: Vec::with_capacity(2 * polynomial.aux_info.max_num_variables),
+            pending_r0: None,
             round: 0,
             poly: polynomial,
             poly_meta: poly_meta.unwrap_or_else(|| vec![PolyMeta::Normal; num_polys]),
@@ -335,6 +336,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         //
         // eval g over r_m, and mutate g to g(r_1, ... r_m,, x_{m+1}... x_n)
         let span = entered_span!("fix_variables");
+        let mut build_with_deferred_first_round = None;
         if self.round > 0 {
             assert!(
                 challenge.is_some(),
@@ -344,7 +346,13 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             let chal = challenge.unwrap();
             self.challenges.push(chal);
             let r = self.challenges.last().unwrap();
-            self.fix_var(r.elements);
+            if self.round == 1 {
+                // Avoid writing round-1 folded MLE evaluations into memory.
+                self.pending_r0 = Some(r.elements);
+                build_with_deferred_first_round = Some(r.elements);
+            } else {
+                self.fix_var(r.elements);
+            }
         }
         exit_span!(span);
         // exit_span!fix_argument);
@@ -354,54 +362,56 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         // Step 2: generate sum for the partial evaluated polynomial:
         // f(r_1, ... r_m,, x_{m+1}... x_n)
         let span = entered_span!("build_uni_poly");
-        let AdditiveVec(mut uni_polys) = self.poly.products.iter().fold(
-            AdditiveVec::new(self.poly.aux_info.max_degree + 1),
-            |mut uni_polys, MonomialTerms { terms }| {
-                for Term {
-                    scalar,
-                    product: prod,
-                } in terms
-                {
-                    let f = &self.poly.flattened_ml_extensions;
-                    let f_type = &self.poly_meta;
-                    let get_poly_meta = || f_type[prod[0]];
-                    let mut uni_variate: Vec<E> = vec![E::ZERO; self.poly.aux_info.max_degree + 1];
-                    let uni_variate_monomial: Vec<E> = match prod.len() {
-                        1 => sumcheck_code_gen!(1, false, |i| &f[prod[i]], || get_poly_meta())
-                            .to_vec(),
-                        2 => sumcheck_code_gen!(2, false, |i| &f[prod[i]], || get_poly_meta())
-                            .to_vec(),
-                        3 => sumcheck_code_gen!(3, false, |i| &f[prod[i]], || get_poly_meta())
-                            .to_vec(),
-                        4 => sumcheck_code_gen!(4, false, |i| &f[prod[i]], || get_poly_meta())
-                            .to_vec(),
-                        5 => sumcheck_code_gen!(5, false, |i| &f[prod[i]], || get_poly_meta())
-                            .to_vec(),
-                        6 => sumcheck_code_gen!(6, false, |i| &f[prod[i]], || get_poly_meta())
-                            .to_vec(),
-                        _ => unimplemented!("do not support degree {} > 6", prod.len()),
-                    };
+        let AdditiveVec(mut uni_polys) = if let Some(r0) = build_with_deferred_first_round {
+            self.build_uni_poly_round2(r0)
+        } else {
+            self.poly.products.iter().fold(
+                AdditiveVec::new(self.poly.aux_info.max_degree + 1),
+                |mut uni_polys, MonomialTerms { terms }| {
+                    for Term {
+                        scalar,
+                        product: prod,
+                    } in terms
+                    {
+                        let f = &self.poly.flattened_ml_extensions;
+                        let f_type = &self.poly_meta;
+                        let get_poly_meta = || f_type[prod[0]];
+                        let mut uni_variate: Vec<E> =
+                            vec![E::ZERO; self.poly.aux_info.max_degree + 1];
+                        let uni_variate_monomial: Vec<E> = match prod.len() {
+                            1 => sumcheck_code_gen!(1, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            2 => sumcheck_code_gen!(2, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            3 => sumcheck_code_gen!(3, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            4 => sumcheck_code_gen!(4, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            5 => sumcheck_code_gen!(5, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            6 => sumcheck_code_gen!(6, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            _ => unimplemented!("do not support degree {} > 6", prod.len()),
+                        };
 
-                    uni_variate
-                        .iter_mut()
-                        .zip(uni_variate_monomial)
-                        .take(prod.len() + 1)
-                        .for_each(|(eval, monimial_eval,)| either::for_both!(scalar, scalar => *eval = monimial_eval**scalar));
+                        uni_variate
+                            .iter_mut()
+                            .zip(uni_variate_monomial)
+                            .take(prod.len() + 1)
+                            .for_each(|(eval, monimial_eval,)| either::for_both!(scalar, scalar => *eval = monimial_eval**scalar));
 
 
-                    if prod.len() < self.poly.aux_info.max_degree {
-                        // Perform extrapolation using the precomputed extrapolation table
-                        extrapolate_from_table(
-                            &mut uni_variate,
-                            prod.len() + 1,
-                        );
+                        if prod.len() < self.poly.aux_info.max_degree {
+                            // Perform extrapolation using the precomputed extrapolation table
+                            extrapolate_from_table(&mut uni_variate, prod.len() + 1);
+                        }
+
+                        uni_polys += AdditiveVec(uni_variate);
                     }
-
-                    uni_polys += AdditiveVec(uni_variate);
-                }
-                uni_polys
-            },
-        );
+                    uni_polys
+                },
+            )
+        };
         exit_span!(span);
 
         exit_span!(start);
@@ -414,6 +424,177 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         IOPProverMessage {
             evaluations: uni_polys,
         }
+    }
+
+    fn mle_eval_at_index(mle: &Arc<multilinear_extensions::mle::MultilinearExtension<'a, E>>, index: usize) -> E {
+        match mle.evaluations() {
+            FieldType::Base(slice) => E::from(slice[index]),
+            FieldType::Ext(slice) => slice[index],
+            FieldType::Unreachable => unreachable!(),
+        }
+    }
+
+    fn mle_eval_round2_without_cached_first_round(
+        mle: &Arc<multilinear_extensions::mle::MultilinearExtension<'a, E>>,
+        offset: usize,
+        r0: E,
+        x: E,
+    ) -> E {
+        let f00 = Self::mle_eval_at_index(mle, offset); // f(0,0,b)
+        let f10 = Self::mle_eval_at_index(mle, offset + 1); // f(1,0,b)
+        let f01 = Self::mle_eval_at_index(mle, offset + 2); // f(0,1,b)
+        let f11 = Self::mle_eval_at_index(mle, offset + 3); // f(1,1,b)
+
+        let y0 = f00 + (f10 - f00) * r0; // f(r0,0,b)
+        let y1 = f01 + (f11 - f01) * r0; // f(r0,1,b)
+        y0 + (y1 - y0) * x // f(r0,x,b)
+    }
+
+    fn mle_eval_single_var(
+        mle: &Arc<multilinear_extensions::mle::MultilinearExtension<'a, E>>,
+        offset: usize,
+        x: E,
+    ) -> E {
+        let y0 = Self::mle_eval_at_index(mle, offset);
+        let y1 = Self::mle_eval_at_index(mle, offset + 1);
+        y0 + (y1 - y0) * x
+    }
+
+    /// build univariate polynomial for round 2 directly from original MLE evaluations
+    /// h(x) = \sum_b f(r0, x, b) 
+    ///      = eq(r0,0)*f(0,x,b) + eq(r0,1)*f(1,x,b)
+    ///      = eq(r0,0)*eq(x,0)*f(0,0,b) 
+    ///        + eq(r0,0)*eq(x,1)*f(0,1,b)
+    ///        + eq(r0,1)*eq(x,0)*f(1,0,b)
+    ///        + eq(r0,1)*eq(x,1)*f(1,1,b)
+    fn build_uni_poly_round2(&self, r0: E) -> AdditiveVec<E> {
+        self.poly.products.iter().fold(
+            AdditiveVec::new(self.poly.aux_info.max_degree + 1),
+            |mut uni_polys, MonomialTerms { terms }| {
+                for Term {
+                    scalar,
+                    product: prod,
+                } in terms
+                {
+                    let f = &self.poly.flattened_ml_extensions;
+                    let poly_type = self.poly_meta[prod[0]];
+                    let num_var = f[prod[0]].num_vars();
+                    // `self.round` has already been incremented before this builder runs.
+                    // Conceptually, round-1 has been fixed, so this is the post-fix expected
+                    // variable count used by the existing code path.
+                    let expected_numvars_post_fix = self.expected_numvars_at_round();
+                    // Since we intentionally deferred the first-round fix, in-memory MLEs still
+                    // carry one extra variable for the max-numvar branch.
+                    let expected_numvars_unfixed = expected_numvars_post_fix + 1;
+
+                    let mut uni_variate = vec![E::ZERO; self.poly.aux_info.max_degree + 1];
+                    let degree = prod.len();
+
+                    let one_term_product_at = |idx: usize| {
+                        prod.iter()
+                            .map(|&poly_idx| Self::mle_eval_at_index(&f[poly_idx], idx))
+                            .product::<E>()
+                    };
+
+                    match poly_type {
+                        PolyMeta::Phase2Only => {
+                            if self.is_main_worker {
+                                let eval_len = f[prod[0]].evaluations().len();
+                                let mut sum = if eval_len == 1 {
+                                    one_term_product_at(0)
+                                } else {
+                                    (0..largest_even_below(eval_len))
+                                        .map(one_term_product_at)
+                                        .sum()
+                                };
+                                let multiplicity = self
+                                    .expected_numvars_at_round()
+                                    .saturating_add(self.phase2_numvar.unwrap_or(0))
+                                    .saturating_sub(1)
+                                    .saturating_sub(num_var);
+                                if multiplicity > 0 {
+                                    let factor = 1u64
+                                        .checked_shl(multiplicity as u32)
+                                        .expect("phase2 multiplicity overflow");
+                                    sum *= E::from_canonical_u64(factor);
+                                }
+                                uni_variate.iter_mut().take(degree + 1).for_each(|v| *v = sum);
+                            }
+                        }
+                        PolyMeta::Normal if num_var + 1 == expected_numvars_unfixed => {
+                            let eval_len = f[prod[0]].evaluations().len();
+                            for x_idx in 0..=degree {
+                                let x = E::from_canonical_u64(x_idx as u64);
+                                let sum = (0..eval_len)
+                                    .step_by(2)
+                                    .map(|b| {
+                                        prod.iter()
+                                            .map(|&poly_idx| {
+                                                Self::mle_eval_single_var(&f[poly_idx], b, x)
+                                            })
+                                            .product::<E>()
+                                    })
+                                    .sum();
+                                uni_variate[x_idx] = sum;
+                            }
+                        }
+                        PolyMeta::Normal if num_var + 1 < expected_numvars_unfixed => {
+                            let eval_len = f[prod[0]].evaluations().len();
+                            let mut sum = if eval_len == 1 {
+                                one_term_product_at(0)
+                            } else {
+                                (0..largest_even_below(eval_len)).map(one_term_product_at).sum()
+                            };
+                            let multiplicity = expected_numvars_post_fix
+                                .saturating_sub(1)
+                                .saturating_sub(num_var);
+                            if multiplicity > 0 {
+                                let factor = 1u64
+                                    .checked_shl(multiplicity as u32)
+                                    .expect("normal multiplicity overflow");
+                                sum *= E::from_canonical_u64(factor);
+                            }
+                            uni_variate.iter_mut().take(degree + 1).for_each(|v| *v = sum);
+                        }
+                        PolyMeta::Normal => {
+                            debug_assert_eq!(num_var, expected_numvars_unfixed);
+                            let eval_len = f[prod[0]].evaluations().len();
+                            for x_idx in 0..=degree {
+                                let x = E::from_canonical_u64(x_idx as u64);
+                                let sum = (0..eval_len)
+                                    .step_by(4)
+                                    .map(|b| {
+                                        prod.iter()
+                                            .map(|&poly_idx| {
+                                                Self::mle_eval_round2_without_cached_first_round(
+                                                    &f[poly_idx],
+                                                    b,
+                                                    r0,
+                                                    x,
+                                                )
+                                            })
+                                            .product::<E>()
+                                    })
+                                    .sum();
+                                uni_variate[x_idx] = sum;
+                            }
+                        }
+                    }
+
+                    uni_variate
+                        .iter_mut()
+                        .take(degree + 1)
+                        .for_each(|eval| either::for_both!(scalar, scalar => *eval *= *scalar));
+
+                    if degree < self.poly.aux_info.max_degree {
+                        extrapolate_from_table(&mut uni_variate, degree + 1);
+                    }
+
+                    uni_polys += AdditiveVec(uni_variate);
+                }
+                uni_polys
+            },
+        )
     }
 
     /// collect all mle evaluation (claim) after sumcheck
@@ -448,6 +629,11 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
 
     /// fix_var
     pub fn fix_var(&mut self, r: E) {
+        if let Some(r0) = self.pending_r0.take() {
+            self.fix_two_vars(r0, r);
+            return;
+        }
+
         let expected_numvars_at_round = self.expected_numvars_at_round();
         self.poly
             .flattened_ml_extensions
@@ -463,6 +649,38 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     } else {
                         let poly = Arc::get_mut(poly).unwrap();
                         poly.fix_variables_in_place(&[r])
+                    }
+                }
+            });
+    }
+
+    fn fix_two_vars(&mut self, r0: E, r1: E) {
+        // At this point we are consuming round-2 challenge `r1` while `r0` was deferred.
+        // - MLEs with num_vars = expected + 1 still need both `r0` and `r1`.
+        // - MLEs with num_vars = expected were independent of the first round variable,
+        //   so they only need `r1`.
+        let expected_numvars_at_round = self.expected_numvars_at_round();
+        self.poly
+            .flattened_ml_extensions
+            .iter_mut()
+            .zip_eq(&self.poly_meta)
+            .for_each(|(poly, poly_type)| {
+                debug_assert!(poly.num_vars() > 0);
+                if matches!(poly_type, PolyMeta::Normal) {
+                    if poly.num_vars() == expected_numvars_at_round + 1 {
+                        if !poly.is_mut() {
+                            *poly = Arc::new(poly.fix_two_variables(r0, r1));
+                        } else {
+                            let poly = Arc::get_mut(poly).unwrap();
+                            poly.fix_two_variables_in_place(r0, r1)
+                        }
+                    } else if poly.num_vars() == expected_numvars_at_round {
+                        if !poly.is_mut() {
+                            *poly = Arc::new(poly.fix_variables(&[r1]));
+                        } else {
+                            let poly = Arc::get_mut(poly).unwrap();
+                            poly.fix_variables_in_place(&[r1])
+                        }
                     }
                 }
             });
@@ -551,6 +769,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             is_main_worker: true,
             max_num_variables: polynomial.aux_info.max_num_variables,
             challenges: Vec::with_capacity(polynomial.aux_info.max_num_variables),
+            pending_r0: None,
             round: 0,
             poly: polynomial,
             poly_meta,

--- a/crates/sumcheck/src/prover.rs
+++ b/crates/sumcheck/src/prover.rs
@@ -1,5 +1,6 @@
 use std::{mem, sync::Arc};
 
+use either::Either;
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use multilinear_extensions::{
@@ -336,7 +337,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         //
         // eval g over r_m, and mutate g to g(r_1, ... r_m,, x_{m+1}... x_n)
         let span = entered_span!("fix_variables");
-        let mut build_with_deferred_first_round = None;
         if self.round > 0 {
             assert!(
                 challenge.is_some(),
@@ -349,7 +349,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             if self.round == 1 {
                 // Avoid writing round-1 folded MLE evaluations into memory.
                 self.pending_r0 = Some(r.elements);
-                build_with_deferred_first_round = Some(r.elements);
             } else {
                 self.fix_var(r.elements);
             }
@@ -362,7 +361,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         // Step 2: generate sum for the partial evaluated polynomial:
         // f(r_1, ... r_m,, x_{m+1}... x_n)
         let span = entered_span!("build_uni_poly");
-        let AdditiveVec(mut uni_polys) = if let Some(r0) = build_with_deferred_first_round {
+        let AdditiveVec(mut uni_polys) = if let Some(r0) = self.pending_r0 {
             self.build_uni_poly_round2(r0)
         } else {
             self.poly.products.iter().fold(
@@ -426,47 +425,49 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         }
     }
 
-    fn mle_eval_at_index(mle: &Arc<multilinear_extensions::mle::MultilinearExtension<'a, E>>, index: usize) -> E {
-        match mle.evaluations() {
-            FieldType::Base(slice) => E::from(slice[index]),
-            FieldType::Ext(slice) => slice[index],
-            FieldType::Unreachable => unreachable!(),
-        }
-    }
-
-    fn mle_eval_round2_without_cached_first_round(
-        mle: &Arc<multilinear_extensions::mle::MultilinearExtension<'a, E>>,
-        offset: usize,
-        r0: E,
-        x: E,
-    ) -> E {
-        let f00 = Self::mle_eval_at_index(mle, offset); // f(0,0,b)
-        let f10 = Self::mle_eval_at_index(mle, offset + 1); // f(1,0,b)
-        let f01 = Self::mle_eval_at_index(mle, offset + 2); // f(0,1,b)
-        let f11 = Self::mle_eval_at_index(mle, offset + 3); // f(1,1,b)
-
-        let y0 = f00 + (f10 - f00) * r0; // f(r0,0,b)
-        let y1 = f01 + (f11 - f01) * r0; // f(r0,1,b)
+    #[inline(always)]
+    fn mle_eval_round2_ext(block: &[E], r0: E, x: E::BaseField) -> E {
+        let y0 = block[0] + (block[1] - block[0]) * r0; // f(r0,0,b)
+        let y1 = block[2] + (block[3] - block[2]) * r0; // f(r0,1,b)
         y0 + (y1 - y0) * x // f(r0,x,b)
     }
 
-    fn mle_eval_single_var(
-        mle: &Arc<multilinear_extensions::mle::MultilinearExtension<'a, E>>,
-        offset: usize,
-        x: E,
-    ) -> E {
-        let y0 = Self::mle_eval_at_index(mle, offset);
-        let y1 = Self::mle_eval_at_index(mle, offset + 1);
-        y0 + (y1 - y0) * x
+    #[inline(always)]
+    fn mle_eval_round2_base(block: &[E::BaseField], r0: E, x: E::BaseField) -> E {
+        let y0 = r0 * (block[1] - block[0]) + block[0]; // f(r0,0,b)
+        let y1 = r0 * (block[3] - block[2]) + block[2]; // f(r0,1,b)
+        y0 + (y1 - y0) * x // f(r0,x,b)
+    }
+
+    #[inline(always)]
+    fn mle_eval_round2(block: Either<&[E::BaseField], &[E]>, r0: E, x: E::BaseField) -> E {
+        match block {
+            Either::Left(b) => Self::mle_eval_round2_base(b, r0, x),
+            Either::Right(b) => Self::mle_eval_round2_ext(b, r0, x),
+        }
+    }
+
+    #[inline(always)]
+    fn mle_eval_round1_ext(block: &[E], x: E::BaseField) -> E {
+        block[0] + (block[1] - block[0]) * x
+    }
+
+    #[inline(always)]
+    fn mle_eval_round1_base(block: &[E::BaseField], x: E::BaseField) -> E {
+        (block[0] + (block[1] - block[0]) * x).into()
+    }
+
+    #[inline(always)]
+    fn mle_eval_round1(block: Either<&[E::BaseField], &[E]>, x: E::BaseField) -> E {
+        match block {
+            Either::Left(b) => Self::mle_eval_round1_base(b, x),
+            Either::Right(b) => Self::mle_eval_round1_ext(b, x),
+        }
     }
 
     /// build univariate polynomial for round 2 directly from original MLE evaluations
-    /// h(x) = \sum_b f(r0, x, b) 
+    /// h(x) = \sum_b f(r0, x, b)
     ///      = eq(r0,0)*f(0,x,b) + eq(r0,1)*f(1,x,b)
-    ///      = eq(r0,0)*eq(x,0)*f(0,0,b) 
-    ///        + eq(r0,0)*eq(x,1)*f(0,1,b)
-    ///        + eq(r0,1)*eq(x,0)*f(1,0,b)
-    ///        + eq(r0,1)*eq(x,1)*f(1,1,b)
     fn build_uni_poly_round2(&self, r0: E) -> AdditiveVec<E> {
         self.poly.products.iter().fold(
             AdditiveVec::new(self.poly.aux_info.max_degree + 1),
@@ -477,108 +478,84 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 } in terms
                 {
                     let f = &self.poly.flattened_ml_extensions;
-                    let poly_type = self.poly_meta[prod[0]];
+                    let get_poly_meta = || self.poly_meta[prod[0]];
                     let num_var = f[prod[0]].num_vars();
-                    // `self.round` has already been incremented before this builder runs.
-                    // Conceptually, round-1 has been fixed, so this is the post-fix expected
-                    // variable count used by the existing code path.
-                    let expected_numvars_post_fix = self.expected_numvars_at_round();
-                    // Since we intentionally deferred the first-round fix, in-memory MLEs still
-                    // carry one extra variable for the max-numvar branch.
-                    let expected_numvars_unfixed = expected_numvars_post_fix + 1;
 
                     let mut uni_variate = vec![E::ZERO; self.poly.aux_info.max_degree + 1];
                     let degree = prod.len();
 
-                    let one_term_product_at = |idx: usize| {
-                        prod.iter()
-                            .map(|&poly_idx| Self::mle_eval_at_index(&f[poly_idx], idx))
-                            .product::<E>()
-                    };
-
-                    match poly_type {
-                        PolyMeta::Phase2Only => {
-                            if self.is_main_worker {
-                                let eval_len = f[prod[0]].evaluations().len();
-                                let mut sum = if eval_len == 1 {
-                                    one_term_product_at(0)
-                                } else {
-                                    (0..largest_even_below(eval_len))
-                                        .map(one_term_product_at)
-                                        .sum()
-                                };
-                                let multiplicity = self
-                                    .expected_numvars_at_round()
-                                    .saturating_add(self.phase2_numvar.unwrap_or(0))
-                                    .saturating_sub(1)
-                                    .saturating_sub(num_var);
-                                if multiplicity > 0 {
-                                    let factor = 1u64
-                                        .checked_shl(multiplicity as u32)
-                                        .expect("phase2 multiplicity overflow");
-                                    sum *= E::from_canonical_u64(factor);
-                                }
-                                uni_variate.iter_mut().take(degree + 1).for_each(|v| *v = sum);
-                            }
+                    if num_var == self.max_num_variables {
+                        // fi(r0,x,b)
+                        let evals_len = f[prod[0]].evaluations().len();
+                        for (x, uni_variate_eval) in
+                            uni_variate.iter_mut().enumerate().take(degree + 1)
+                        {
+                            let x_felt = E::BaseField::from_canonical_u32(x as u32);
+                            let sum = (0..evals_len)
+                                .step_by(4)
+                                .map(|b| {
+                                    prod.iter()
+                                        .map(|&poly_idx| {
+                                            Self::mle_eval_round2(
+                                                f[poly_idx]
+                                                    .as_ref()
+                                                    .evaluations()
+                                                    .as_slice(b..b + 4),
+                                                r0,
+                                                x_felt,
+                                            )
+                                        })
+                                        .product::<E>()
+                                })
+                                .sum();
+                            *uni_variate_eval = sum;
                         }
-                        PolyMeta::Normal if num_var + 1 == expected_numvars_unfixed => {
-                            let eval_len = f[prod[0]].evaluations().len();
-                            for x_idx in 0..=degree {
-                                let x = E::from_canonical_u64(x_idx as u64);
-                                let sum = (0..eval_len)
-                                    .step_by(2)
-                                    .map(|b| {
-                                        prod.iter()
-                                            .map(|&poly_idx| {
-                                                Self::mle_eval_single_var(&f[poly_idx], b, x)
-                                            })
-                                            .product::<E>()
-                                    })
-                                    .sum();
-                                uni_variate[x_idx] = sum;
-                            }
+                    } else if num_var + 1 == self.max_num_variables {
+                        // fi(x,b)
+                        let evals_len = f[prod[0]].evaluations().len();
+                        for (x, uni_variate_eval) in
+                            uni_variate.iter_mut().enumerate().take(degree + 1)
+                        {
+                            let x_felt = E::BaseField::from_canonical_u32(x as u32);
+                            let sum = (0..evals_len)
+                                .step_by(2)
+                                .map(|b| {
+                                    prod.iter()
+                                        .map(|&poly_idx| {
+                                            Self::mle_eval_round1(
+                                                f[poly_idx]
+                                                    .as_ref()
+                                                    .evaluations()
+                                                    .as_slice(b..b + 2),
+                                                x_felt,
+                                            )
+                                        })
+                                        .product::<E>()
+                                })
+                                .sum();
+                            *uni_variate_eval = sum;
                         }
-                        PolyMeta::Normal if num_var + 1 < expected_numvars_unfixed => {
-                            let eval_len = f[prod[0]].evaluations().len();
-                            let mut sum = if eval_len == 1 {
-                                one_term_product_at(0)
-                            } else {
-                                (0..largest_even_below(eval_len)).map(one_term_product_at).sum()
-                            };
-                            let multiplicity = expected_numvars_post_fix
-                                .saturating_sub(1)
-                                .saturating_sub(num_var);
-                            if multiplicity > 0 {
-                                let factor = 1u64
-                                    .checked_shl(multiplicity as u32)
-                                    .expect("normal multiplicity overflow");
-                                sum *= E::from_canonical_u64(factor);
-                            }
-                            uni_variate.iter_mut().take(degree + 1).for_each(|v| *v = sum);
-                        }
-                        PolyMeta::Normal => {
-                            debug_assert_eq!(num_var, expected_numvars_unfixed);
-                            let eval_len = f[prod[0]].evaluations().len();
-                            for x_idx in 0..=degree {
-                                let x = E::from_canonical_u64(x_idx as u64);
-                                let sum = (0..eval_len)
-                                    .step_by(4)
-                                    .map(|b| {
-                                        prod.iter()
-                                            .map(|&poly_idx| {
-                                                Self::mle_eval_round2_without_cached_first_round(
-                                                    &f[poly_idx],
-                                                    b,
-                                                    r0,
-                                                    x,
-                                                )
-                                            })
-                                            .product::<E>()
-                                    })
-                                    .sum();
-                                uni_variate[x_idx] = sum;
-                            }
-                        }
+                    } else {
+                        let uni_variate_monomial: Vec<E> = match prod.len() {
+                            1 => sumcheck_code_gen!(1, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            2 => sumcheck_code_gen!(2, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            3 => sumcheck_code_gen!(3, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            4 => sumcheck_code_gen!(4, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            5 => sumcheck_code_gen!(5, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            6 => sumcheck_code_gen!(6, false, |i| &f[prod[i]], || get_poly_meta())
+                                .to_vec(),
+                            _ => unimplemented!("do not support degree {} > 6", prod.len()),
+                        };
+                        uni_variate
+                            .iter_mut()
+                            .zip(uni_variate_monomial)
+                            .take(degree + 1)
+                            .for_each(|(eval, monomial_eval)| *eval = monomial_eval);
                     }
 
                     uni_variate

--- a/crates/sumcheck/src/prover.rs
+++ b/crates/sumcheck/src/prover.rs
@@ -492,43 +492,48 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         )
     }
 
+    /// Returns `(y0, dy)` where `y0 = fi(r0, 0, b)` and `dy = fi(r0, 1, b) - y0`,
+    /// so that `fi(r0, x, b) = y0 + dy * x` for any `x`.
+    /// Computing these once per block amortises the r0 multiplications across all x values.
     #[inline(always)]
-    fn mle_eval_round2_ext(block: &[E], r0: E, x: E::BaseField) -> E {
-        let y0 = block[0] + (block[1] - block[0]) * r0; // f(r0,0,b)
-        let y1 = block[2] + (block[3] - block[2]) * r0; // f(r0,1,b)
-        y0 + (y1 - y0) * x // f(r0,x,b)
+    fn mle_eval_round2_endpoints_ext(block: &[E], r0: E) -> (E, E) {
+        let y0 = block[0] + (block[1] - block[0]) * r0;
+        let y1 = block[2] + (block[3] - block[2]) * r0;
+        (y0, y1 - y0)
     }
 
     #[inline(always)]
-    fn mle_eval_round2_base(block: &[E::BaseField], r0: E, x: E::BaseField) -> E {
-        let y0 = r0 * (block[1] - block[0]) + block[0]; // f(r0,0,b)
-        let y1 = r0 * (block[3] - block[2]) + block[2]; // f(r0,1,b)
-        y0 + (y1 - y0) * x // f(r0,x,b)
+    fn mle_eval_round2_endpoints_base(block: &[E::BaseField], r0: E) -> (E, E) {
+        let y0 = r0 * (block[1] - block[0]) + block[0];
+        let y1 = r0 * (block[3] - block[2]) + block[2];
+        (y0, y1 - y0)
     }
 
     #[inline(always)]
-    fn mle_eval_round2(block: Either<&[E::BaseField], &[E]>, r0: E, x: E::BaseField) -> E {
+    fn mle_eval_round2_endpoints(block: Either<&[E::BaseField], &[E]>, r0: E) -> (E, E) {
         match block {
-            Either::Left(b) => Self::mle_eval_round2_base(b, r0, x),
-            Either::Right(b) => Self::mle_eval_round2_ext(b, r0, x),
+            Either::Left(b) => Self::mle_eval_round2_endpoints_base(b, r0),
+            Either::Right(b) => Self::mle_eval_round2_endpoints_ext(b, r0),
         }
     }
 
+    /// Returns `(y0, dy)` where `y0 = fi(0, b)` and `dy = fi(1, b) - y0`,
+    /// so that `fi(x, b) = y0 + dy * x` for any `x`.
     #[inline(always)]
-    fn mle_eval_round1_ext(block: &[E], x: E::BaseField) -> E {
-        block[0] + (block[1] - block[0]) * x
+    fn mle_eval_round1_endpoints_ext(block: &[E]) -> (E, E) {
+        (block[0], block[1] - block[0])
     }
 
     #[inline(always)]
-    fn mle_eval_round1_base(block: &[E::BaseField], x: E::BaseField) -> E {
-        (block[0] + (block[1] - block[0]) * x).into()
+    fn mle_eval_round1_endpoints_base(block: &[E::BaseField]) -> (E, E) {
+        (block[0].into(), (block[1] - block[0]).into())
     }
 
     #[inline(always)]
-    fn mle_eval_round1(block: Either<&[E::BaseField], &[E]>, x: E::BaseField) -> E {
+    fn mle_eval_round1_endpoints(block: Either<&[E::BaseField], &[E]>) -> (E, E) {
         match block {
-            Either::Left(b) => Self::mle_eval_round1_base(b, x),
-            Either::Right(b) => Self::mle_eval_round1_ext(b, x),
+            Either::Left(b) => Self::mle_eval_round1_endpoints_base(b),
+            Either::Right(b) => Self::mle_eval_round1_endpoints_ext(b),
         }
     }
 
@@ -552,55 +557,50 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     let degree = prod.len();
 
                     if num_var == self.max_num_variables {
-                        // fi(r0,x,b)
+                        // Batch all x-evaluations per block b.
+                        // For each b, compute (y0_i, dy_i) = (fi(r0,0,b), fi(r0,1,b)-fi(r0,0,b))
+                        // once, then evaluate fi(r0,x,b) = y0_i + dy_i*x for every x.
+                        // This amortises the r0 multiplications across all x values.
                         let evals_len = f[prod[0]].evaluations().len();
-                        for (x, uni_variate_eval) in
-                            uni_variate.iter_mut().enumerate().take(degree + 1)
-                        {
-                            let x_felt = E::BaseField::from_canonical_u32(x as u32);
-                            let sum = (0..evals_len)
-                                .step_by(4)
-                                .map(|b| {
-                                    prod.iter()
-                                        .map(|&poly_idx| {
-                                            Self::mle_eval_round2(
-                                                f[poly_idx]
-                                                    .as_ref()
-                                                    .evaluations()
-                                                    .as_slice(b..b + 4),
-                                                r0,
-                                                x_felt,
-                                            )
-                                        })
-                                        .product::<E>()
-                                })
-                                .sum();
-                            *uni_variate_eval = sum;
+                        let x_felts: Vec<E::BaseField> = (0..=degree)
+                            .map(|x| E::BaseField::from_canonical_u32(x as u32))
+                            .collect();
+                        let mut endpoints = vec![(E::ZERO, E::ZERO); degree];
+                        for b in (0..evals_len).step_by(4) {
+                            for (k, &poly_idx) in prod.iter().enumerate() {
+                                endpoints[k] = Self::mle_eval_round2_endpoints(
+                                    f[poly_idx].as_ref().evaluations().as_slice(b..b + 4),
+                                    r0,
+                                );
+                            }
+                            for (x, &x_felt) in x_felts.iter().enumerate() {
+                                uni_variate[x] += endpoints
+                                    .iter()
+                                    .map(|&(y0, dy)| y0 + dy * x_felt)
+                                    .product::<E>();
+                            }
                         }
                     } else if num_var + 1 == self.max_num_variables {
-                        // fi(x,b)
+                        // Same batch trick for the phase-1 case fi(x,b):
+                        // compute (y0_i, dy_i) = (fi(0,b), fi(1,b)-fi(0,b)) once per b,
+                        // then evaluate for all x.
                         let evals_len = f[prod[0]].evaluations().len();
-                        for (x, uni_variate_eval) in
-                            uni_variate.iter_mut().enumerate().take(degree + 1)
-                        {
-                            let x_felt = E::BaseField::from_canonical_u32(x as u32);
-                            let sum = (0..evals_len)
-                                .step_by(2)
-                                .map(|b| {
-                                    prod.iter()
-                                        .map(|&poly_idx| {
-                                            Self::mle_eval_round1(
-                                                f[poly_idx]
-                                                    .as_ref()
-                                                    .evaluations()
-                                                    .as_slice(b..b + 2),
-                                                x_felt,
-                                            )
-                                        })
-                                        .product::<E>()
-                                })
-                                .sum();
-                            *uni_variate_eval = sum;
+                        let x_felts: Vec<E::BaseField> = (0..=degree)
+                            .map(|x| E::BaseField::from_canonical_u32(x as u32))
+                            .collect();
+                        let mut endpoints = vec![(E::ZERO, E::ZERO); degree];
+                        for b in (0..evals_len).step_by(2) {
+                            for (k, &poly_idx) in prod.iter().enumerate() {
+                                endpoints[k] = Self::mle_eval_round1_endpoints(
+                                    f[poly_idx].as_ref().evaluations().as_slice(b..b + 2),
+                                );
+                            }
+                            for (x, &x_felt) in x_felts.iter().enumerate() {
+                                uni_variate[x] += endpoints
+                                    .iter()
+                                    .map(|&(y0, dy)| y0 + dy * x_felt)
+                                    .product::<E>();
+                            }
                         }
                     } else {
                         let uni_variate_monomial: Vec<E> = match prod.len() {

--- a/crates/sumcheck/src/prover.rs
+++ b/crates/sumcheck/src/prover.rs
@@ -18,7 +18,10 @@ use transcript::{Challenge, Transcript};
 use crate::{
     extrapolate::ExtrapolationCache,
     macros::{entered_span, exit_span},
-    structs::{IOPProof, IOPProverMessage, IOPProverState},
+    structs::{
+        IOPProof, IOPProverMessage, IOPProverState, ProverInnerContext, ReducedPeakMemoryContext,
+        SumcheckProverMode,
+    },
     util::{
         AdditiveArray, AdditiveVec, extrapolate_from_table, merge_sumcheck_polys,
         merge_sumcheck_prover_state,
@@ -91,13 +94,15 @@ impl<'a, E: ExtensionField> Phase1WorkerState<'a, E> {
         poly: VirtualPolynomial<'a, E>,
         phase2_numvar: usize,
         poly_meta: Option<Vec<PolyMeta>>,
+        mode: SumcheckProverMode,
     ) -> Self {
         Self {
-            prover_state: IOPProverState::prover_init_with_extrapolation_aux(
+            prover_state: IOPProverState::prover_init_with_extrapolation_aux_with_mode(
                 is_main_worker,
                 poly,
                 Some(phase2_numvar),
                 poly_meta,
+                mode,
             ),
             challenge: None,
         }
@@ -125,6 +130,22 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         virtual_poly: VirtualPolynomials<'a, E>,
         transcript: &mut impl Transcript<E>,
     ) -> (IOPProof<E>, IOPProverState<'a, E>) {
+        Self::prove_with_mode(virtual_poly, transcript, SumcheckProverMode::LegacyStable)
+    }
+
+    #[tracing::instrument(
+        skip_all,
+        name = "sumcheck::prove_with_mode",
+        level = "trace",
+        fields(profiling_5)
+    )]
+    pub fn prove_with_mode(
+        virtual_poly: VirtualPolynomials<'a, E>,
+        transcript: &mut impl Transcript<E>,
+        mode: SumcheckProverMode,
+    ) -> (IOPProof<E>, IOPProverState<'a, E>) {
+        // Runtime mode is threaded through both phase-1 workers and merged phase-2 state
+        // so a caller gets consistent flow selection for the full proof.
         let max_thread_id = virtual_poly.num_threads;
         let (polys, poly_meta) = virtual_poly.get_batched_polys();
 
@@ -171,6 +192,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 max_degree,
                 polys,
                 transcript,
+                mode,
             );
             exit_span!(span);
             if log2_max_thread_id == 0 {
@@ -185,17 +207,18 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             let span = entered_span!("merged_poly", profiling_6 = true);
             let poly = merge_sumcheck_prover_state(&prover_states);
             let mut phase2_sumcheck_state =
-                Self::prover_init_with_extrapolation_aux(true, poly, None, None);
+                Self::prover_init_with_extrapolation_aux_with_mode(true, poly, None, None, mode);
             phase2_sumcheck_state.push_challenges(prover_states[0].challenges.clone());
             exit_span!(span);
             (phase2_sumcheck_state, prover_msgs)
         } else {
             (
-                Self::prover_init_with_extrapolation_aux(
+                Self::prover_init_with_extrapolation_aux_with_mode(
                     true,
                     merge_sumcheck_polys(polys.iter().collect_vec(), Some(poly_meta)),
                     None,
                     None,
+                    mode,
                 ),
                 vec![],
             )
@@ -239,6 +262,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         max_degree: usize,
         mut polys: Vec<VirtualPolynomial<'a, E>>,
         transcript: &mut impl Transcript<E>,
+        mode: SumcheckProverMode,
     ) -> (Vec<IOPProverState<'a, E>>, Vec<IOPProverMessage<E>>) {
         let log2_max_thread_id = ceil_log2(max_thread_id); // do not support SIZE not power of 2
 
@@ -253,6 +277,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     mem::take(poly),
                     log2_max_thread_id,
                     Some(poly_meta.clone()),
+                    mode,
                 )
             })
             .collect();
@@ -271,6 +296,22 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         polynomial: VirtualPolynomial<'a, E>,
         phase2_numvar: Option<usize>,
         poly_meta: Option<Vec<PolyMeta>>,
+    ) -> Self {
+        Self::prover_init_with_extrapolation_aux_with_mode(
+            is_main_worker,
+            polynomial,
+            phase2_numvar,
+            poly_meta,
+            SumcheckProverMode::LegacyStable,
+        )
+    }
+
+    pub fn prover_init_with_extrapolation_aux_with_mode(
+        is_main_worker: bool,
+        polynomial: VirtualPolynomial<'a, E>,
+        phase2_numvar: Option<usize>,
+        poly_meta: Option<Vec<PolyMeta>>,
+        mode: SumcheckProverMode,
     ) -> Self {
         let start = entered_span!("sum check prover init");
         assert_ne!(
@@ -295,7 +336,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             // This accounts for multiple phases and potential continuation challenges,
             // ensuring we avoid reallocations when the protocol spans multiple rounds
             challenges: Vec::with_capacity(2 * polynomial.aux_info.max_num_variables),
-            pending_r0: None,
+            inner_ctx: ProverInnerContext::from_mode(mode),
             round: 0,
             poly: polynomial,
             poly_meta: poly_meta.unwrap_or_else(|| vec![PolyMeta::Normal; num_polys]),
@@ -346,12 +387,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             let chal = challenge.unwrap();
             self.challenges.push(chal);
             let r = self.challenges.last().unwrap();
-            if self.round == 1 {
-                // Avoid writing round-1 folded MLE evaluations into memory.
-                self.pending_r0 = Some(r.elements);
-            } else {
-                self.fix_var(r.elements);
-            }
+            self.handle_round_challenge(r.elements);
         }
         exit_span!(span);
         // exit_span!fix_argument);
@@ -361,56 +397,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         // Step 2: generate sum for the partial evaluated polynomial:
         // f(r_1, ... r_m,, x_{m+1}... x_n)
         let span = entered_span!("build_uni_poly");
-        let AdditiveVec(mut uni_polys) = if let Some(r0) = self.pending_r0 {
-            self.build_uni_poly_round2(r0)
-        } else {
-            self.poly.products.iter().fold(
-                AdditiveVec::new(self.poly.aux_info.max_degree + 1),
-                |mut uni_polys, MonomialTerms { terms }| {
-                    for Term {
-                        scalar,
-                        product: prod,
-                    } in terms
-                    {
-                        let f = &self.poly.flattened_ml_extensions;
-                        let f_type = &self.poly_meta;
-                        let get_poly_meta = || f_type[prod[0]];
-                        let mut uni_variate: Vec<E> =
-                            vec![E::ZERO; self.poly.aux_info.max_degree + 1];
-                        let uni_variate_monomial: Vec<E> = match prod.len() {
-                            1 => sumcheck_code_gen!(1, false, |i| &f[prod[i]], || get_poly_meta())
-                                .to_vec(),
-                            2 => sumcheck_code_gen!(2, false, |i| &f[prod[i]], || get_poly_meta())
-                                .to_vec(),
-                            3 => sumcheck_code_gen!(3, false, |i| &f[prod[i]], || get_poly_meta())
-                                .to_vec(),
-                            4 => sumcheck_code_gen!(4, false, |i| &f[prod[i]], || get_poly_meta())
-                                .to_vec(),
-                            5 => sumcheck_code_gen!(5, false, |i| &f[prod[i]], || get_poly_meta())
-                                .to_vec(),
-                            6 => sumcheck_code_gen!(6, false, |i| &f[prod[i]], || get_poly_meta())
-                                .to_vec(),
-                            _ => unimplemented!("do not support degree {} > 6", prod.len()),
-                        };
-
-                        uni_variate
-                            .iter_mut()
-                            .zip(uni_variate_monomial)
-                            .take(prod.len() + 1)
-                            .for_each(|(eval, monimial_eval,)| either::for_both!(scalar, scalar => *eval = monimial_eval**scalar));
-
-
-                        if prod.len() < self.poly.aux_info.max_degree {
-                            // Perform extrapolation using the precomputed extrapolation table
-                            extrapolate_from_table(&mut uni_variate, prod.len() + 1);
-                        }
-
-                        uni_polys += AdditiveVec(uni_variate);
-                    }
-                    uni_polys
-                },
-            )
-        };
+        let AdditiveVec(mut uni_polys) = self.build_uni_poly_with_context();
         exit_span!(span);
 
         exit_span!(start);
@@ -423,6 +410,80 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         IOPProverMessage {
             evaluations: uni_polys,
         }
+    }
+
+    #[inline]
+    fn handle_round_challenge(&mut self, r: E) {
+        match &mut self.inner_ctx {
+            ProverInnerContext::Legacy(_) => self.fix_var(r),
+            ProverInnerContext::ReducedPeakMemory(ctx) => {
+                if self.round == 1 {
+                    // Defer first challenge fix and avoid materializing round-1 folded buffers.
+                    ctx.pending_r0 = Some(r);
+                } else {
+                    self.fix_var(r);
+                }
+            }
+        }
+    }
+
+    fn build_uni_poly_with_context(&self) -> AdditiveVec<E> {
+        match &self.inner_ctx {
+            ProverInnerContext::ReducedPeakMemory(ReducedPeakMemoryContext {
+                pending_r0: Some(r0),
+            }) => self.build_uni_poly_round2(*r0),
+            // Legacy, or reduced-memory before deferral is armed, share default path.
+            _ => self.build_uni_poly_default(),
+        }
+    }
+
+    fn build_uni_poly_default(&self) -> AdditiveVec<E> {
+        self.poly.products.iter().fold(
+            AdditiveVec::new(self.poly.aux_info.max_degree + 1),
+            |mut uni_polys, MonomialTerms { terms }| {
+                for Term {
+                    scalar,
+                    product: prod,
+                } in terms
+                {
+                    let f = &self.poly.flattened_ml_extensions;
+                    let f_type = &self.poly_meta;
+                    let get_poly_meta = || f_type[prod[0]];
+                    let mut uni_variate: Vec<E> = vec![E::ZERO; self.poly.aux_info.max_degree + 1];
+                    let uni_variate_monomial: Vec<E> = match prod.len() {
+                        1 => sumcheck_code_gen!(1, false, |i| &f[prod[i]], || get_poly_meta())
+                            .to_vec(),
+                        2 => sumcheck_code_gen!(2, false, |i| &f[prod[i]], || get_poly_meta())
+                            .to_vec(),
+                        3 => sumcheck_code_gen!(3, false, |i| &f[prod[i]], || get_poly_meta())
+                            .to_vec(),
+                        4 => sumcheck_code_gen!(4, false, |i| &f[prod[i]], || get_poly_meta())
+                            .to_vec(),
+                        5 => sumcheck_code_gen!(5, false, |i| &f[prod[i]], || get_poly_meta())
+                            .to_vec(),
+                        6 => sumcheck_code_gen!(6, false, |i| &f[prod[i]], || get_poly_meta())
+                            .to_vec(),
+                        _ => unimplemented!("do not support degree {} > 6", prod.len()),
+                    };
+
+                    uni_variate
+                        .iter_mut()
+                        .zip(uni_variate_monomial)
+                        .take(prod.len() + 1)
+                        .for_each(|(eval, monimial_eval)| {
+                            either::for_both!(scalar, scalar => *eval = monimial_eval * *scalar)
+                        });
+
+                    if prod.len() < self.poly.aux_info.max_degree {
+                        // Perform extrapolation using the precomputed extrapolation table.
+                        extrapolate_from_table(&mut uni_variate, prod.len() + 1);
+                    }
+
+                    uni_polys += AdditiveVec(uni_variate);
+                }
+                uni_polys
+            },
+        )
     }
 
     #[inline(always)]
@@ -606,9 +667,11 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
 
     /// fix_var
     pub fn fix_var(&mut self, r: E) {
-        if let Some(r0) = self.pending_r0.take() {
-            self.fix_two_vars(r0, r);
-            return;
+        if let ProverInnerContext::ReducedPeakMemory(ctx) = &mut self.inner_ctx {
+            if let Some(r0) = ctx.pending_r0.take() {
+                self.fix_two_vars(r0, r);
+                return;
+            }
         }
 
         let expected_numvars_at_round = self.expected_numvars_at_round();
@@ -661,6 +724,20 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     }
                 }
             });
+    }
+
+    pub fn set_prover_mode(&mut self, mode: SumcheckProverMode) {
+        // This resets mode-specific transient state (e.g. deferred r0) intentionally.
+        self.inner_ctx = ProverInnerContext::from_mode(mode);
+    }
+
+    pub fn with_prover_mode(mut self, mode: SumcheckProverMode) -> Self {
+        self.set_prover_mode(mode);
+        self
+    }
+
+    pub fn prover_mode(&self) -> SumcheckProverMode {
+        self.inner_ctx.mode()
     }
 }
 
@@ -746,7 +823,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             is_main_worker: true,
             max_num_variables: polynomial.aux_info.max_num_variables,
             challenges: Vec::with_capacity(polynomial.aux_info.max_num_variables),
-            pending_r0: None,
+            inner_ctx: ProverInnerContext::from_mode(SumcheckProverMode::LegacyStable),
             round: 0,
             poly: polynomial,
             poly_meta,

--- a/crates/sumcheck/src/prover.rs
+++ b/crates/sumcheck/src/prover.rs
@@ -130,7 +130,12 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         virtual_poly: VirtualPolynomials<'a, E>,
         transcript: &mut impl Transcript<E>,
     ) -> (IOPProof<E>, IOPProverState<'a, E>) {
-        Self::prove_with_mode(virtual_poly, transcript, SumcheckProverMode::LegacyStable)
+        #[cfg(feature = "reduce-peak-memory")]
+        let mode = SumcheckProverMode::ReducedPeakMemory;
+        #[cfg(not(feature = "reduce-peak-memory"))]
+        let mode = SumcheckProverMode::LegacyStable;
+
+        Self::prove_with_mode(virtual_poly, transcript, mode)
     }
 
     #[tracing::instrument(
@@ -556,7 +561,9 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     let mut uni_variate = vec![E::ZERO; self.poly.aux_info.max_degree + 1];
                     let degree = prod.len();
 
-                    if num_var == self.max_num_variables {
+                    if num_var == self.max_num_variables
+                        && matches!(get_poly_meta(), PolyMeta::Normal)
+                    {
                         // Batch all x-evaluations per block b.
                         // For each b, compute (y0_i, dy_i) = (fi(r0,0,b), fi(r0,1,b)-fi(r0,0,b))
                         // once, then evaluate fi(r0,x,b) = y0_i + dy_i*x for every x.
@@ -580,7 +587,9 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                                     .product::<E>();
                             }
                         }
-                    } else if num_var + 1 == self.max_num_variables {
+                    } else if num_var + 1 == self.max_num_variables
+                        && matches!(get_poly_meta(), PolyMeta::Normal)
+                    {
                         // Same batch trick for the phase-1 case fi(x,b):
                         // compute (y0_i, dy_i) = (fi(0,b), fi(1,b)-fi(0,b)) once per b,
                         // then evaluate for all x.

--- a/crates/sumcheck/src/structs.rs
+++ b/crates/sumcheck/src/structs.rs
@@ -27,14 +27,64 @@ pub struct IOPProverMessage<E: ExtensionField> {
     pub evaluations: Vec<E>,
 }
 
+/// Runtime mode for sumcheck prover internals.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SumcheckProverMode {
+    /// Legacy, allocation-stable path used by default for compatibility.
+    #[default]
+    LegacyStable,
+    /// Reduce peak memory by deferring first-round fixing and using direct round-2 evaluation.
+    ReducedPeakMemory,
+}
+
+#[derive(Default)]
+pub(crate) struct LegacyProverContext;
+
+#[derive(Default)]
+pub(crate) struct ReducedPeakMemoryContext<E: ExtensionField> {
+    /// Defer fixing the MLEs until the second-round challenge arrives.
+    pub pending_r0: Option<E>,
+}
+
+pub(crate) enum ProverInnerContext<E: ExtensionField> {
+    // Standard path: fix one variable each round and use existing univariate builder.
+    Legacy(LegacyProverContext),
+    // Optimized path: defer r0 handling and fuse first two rounds to lower peak memory.
+    ReducedPeakMemory(ReducedPeakMemoryContext<E>),
+}
+
+impl<E: ExtensionField> Default for ProverInnerContext<E> {
+    fn default() -> Self {
+        Self::Legacy(LegacyProverContext)
+    }
+}
+
+impl<E: ExtensionField> ProverInnerContext<E> {
+    pub(crate) fn mode(&self) -> SumcheckProverMode {
+        match self {
+            Self::Legacy(_) => SumcheckProverMode::LegacyStable,
+            Self::ReducedPeakMemory(_) => SumcheckProverMode::ReducedPeakMemory,
+        }
+    }
+
+    pub(crate) fn from_mode(mode: SumcheckProverMode) -> Self {
+        match mode {
+            SumcheckProverMode::LegacyStable => Self::Legacy(LegacyProverContext),
+            SumcheckProverMode::ReducedPeakMemory => {
+                Self::ReducedPeakMemory(ReducedPeakMemoryContext::default())
+            }
+        }
+    }
+}
+
 /// Prover State of a PolyIOP.
 #[derive(Default)]
 pub struct IOPProverState<'a, E: ExtensionField> {
     pub is_main_worker: bool,
     /// sampled randomness given by the verifier
     pub challenges: Vec<Challenge<E>>,
-    /// Defer fixing the MLEs until the second-round challenge arrives.
-    pub(crate) pending_r0: Option<E>,
+    /// Per-mode internal state for divergent prover flows.
+    pub(crate) inner_ctx: ProverInnerContext<E>,
     /// the current round number
     pub(crate) round: usize,
     /// pointer to the virtual polynomial

--- a/crates/sumcheck/src/structs.rs
+++ b/crates/sumcheck/src/structs.rs
@@ -33,6 +33,8 @@ pub struct IOPProverState<'a, E: ExtensionField> {
     pub is_main_worker: bool,
     /// sampled randomness given by the verifier
     pub challenges: Vec<Challenge<E>>,
+    /// Defer fixing the MLEs until the second-round challenge arrives.
+    pub(crate) pending_r0: Option<E>,
     /// the current round number
     pub(crate) round: usize,
     /// pointer to the virtual polynomial

--- a/crates/sumcheck/src/test.rs
+++ b/crates/sumcheck/src/test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    structs::{IOPProverState, IOPVerifierState},
+    structs::{IOPProverState, IOPVerifierState, SumcheckProverMode},
     util::extrapolate_uni_poly,
 };
 use either::Either;
@@ -81,6 +81,74 @@ fn test_sumcheck_with_different_degree_helper<E: ExtensionField>(num_threads: us
     let mut transcript = BasicTranscript::<E>::new(b"test");
     let (proof_mut, _) = IOPProverState::<E>::prove(poly, &mut transcript);
     assert_eq!(proof, proof_mut, "different proof");
+}
+
+#[test]
+fn test_runtime_prover_modes_are_compatible() {
+    test_runtime_prover_modes_are_compatible_helper::<GoldilocksExt2>();
+    test_runtime_prover_modes_are_compatible_helper::<BabyBearExt4>();
+}
+
+fn test_runtime_prover_modes_are_compatible_helper<E: ExtensionField>() {
+    let mut rng = thread_rng();
+    let nv = vec![8];
+    let degree = 4;
+    let num_products = 4;
+
+    let max_num_variables = *nv.iter().max().unwrap();
+    let (mut monimials, asserted_sum) = VirtualPolynomials::<E>::random_monimials(
+        &nv,
+        (degree, degree + 1),
+        num_products,
+        &mut rng,
+    );
+    let poly = VirtualPolynomials::<E>::new_from_monimials(
+        1,
+        max_num_variables,
+        monimials
+            .iter_mut()
+            .map(|Term { scalar, product }| Term {
+                scalar: Either::Right(*scalar),
+                product: product.iter_mut().map(Either::Right).collect_vec(),
+            })
+            .collect_vec(),
+    );
+
+    let mut transcript_legacy = BasicTranscript::<E>::new(b"mode-test");
+    let (proof_legacy, _) = IOPProverState::<E>::prove(poly.as_view(), &mut transcript_legacy);
+
+    let mut transcript_reduced = BasicTranscript::<E>::new(b"mode-test");
+    let (proof_reduced, _) = IOPProverState::<E>::prove_with_mode(
+        poly.as_view(),
+        &mut transcript_reduced,
+        SumcheckProverMode::ReducedPeakMemory,
+    );
+
+    let mut verifier_transcript_legacy = BasicTranscript::<E>::new(b"mode-test");
+    let legacy_subclaim = IOPVerifierState::<E>::verify(
+        asserted_sum,
+        &proof_legacy,
+        &VPAuxInfo {
+            max_degree: degree,
+            max_num_variables,
+            ..Default::default()
+        },
+        &mut verifier_transcript_legacy,
+    );
+
+    let mut verifier_transcript_reduced = BasicTranscript::<E>::new(b"mode-test");
+    let reduced_subclaim = IOPVerifierState::<E>::verify(
+        asserted_sum,
+        &proof_reduced,
+        &VPAuxInfo {
+            max_degree: degree,
+            max_num_variables,
+            ..Default::default()
+        },
+        &mut verifier_transcript_reduced,
+    );
+
+    assert_eq!(legacy_subclaim, reduced_subclaim);
 }
 
 fn test_sumcheck<E: ExtensionField>(


### PR DESCRIPTION
## Idea

https://github.com/scroll-tech/ceno/issues/1274

1. Build 2nd round univariate polynomial $h_2(x) = \sum_{\vec{b}} \prod_i f_i(r_1, x, \vec{b})$ directly from the initial evaluations (without fold with the first challenge `r1`) assuming sumcheck proof starts from round 1.

2. Fix the evaluations after getting two challenges `(r1, r2)`. That is, fix two variables at one step, $f_i(r_1, r_2, \vec{b})$.

### Special cases  
- For multilinear polynomial $f_i$ that has less variables than the maximum, the contribution of $f_i$ to the $h_2(x)$ is $\sum_{\vec{b}} \prod_i f_i(x, \vec{b})$
- For multilinear polynomial $f_i$ that has `max - 1` variables, fixing two variables at one step, is equivalent to fix the 2nd variable by $r_2$, aka. $f_i(r_2, \vec{b})$.

## Performance

Trade-off: **2x memory reduction at a ~40–50% time cost**.

```
  nv = 25

  ┌──────────────────────┬───────────┬───────────────┬────────┐
  │       Variant        │ LegacySta │ ReducedPeakMe │ Overhe │
  │                      │    ble    │     mory      │   ad   │
  ├──────────────────────┼───────────┼───────────────┼────────┤
  │ prove_sumcheck       │ 1.437 s   │ 2.073 s       │ +44%   │
  ├──────────────────────┼───────────┼───────────────┼────────┤
  │ prove_sumcheck_ext   │ 2.249 s   │ 3.085 s       │ +37%   │
  ├──────────────────────┼───────────┼───────────────┼────────┤
  │ prove_sumcheck_ext_i │ 2.355 s   │ 3.049 s       │ +29%   │
  │ n_place              │           │               │        │
  └──────────────────────┴───────────┴───────────────┴────────┘

  nv = 26

  ┌──────────────────────┬───────────┬───────────────┬────────┐
  │       Variant        │ LegacySta │ ReducedPeakMe │ Overhe │
  │                      │    ble    │     mory      │   ad   │
  ├──────────────────────┼───────────┼───────────────┼────────┤
  │ prove_sumcheck       │ 2.961 s   │ 4.142 s       │ +40%   │
  ├──────────────────────┼───────────┼───────────────┼────────┤
  │ prove_sumcheck_ext   │ 4.589 s   │ 6.838 s       │ +49%   │
  ├──────────────────────┼───────────┼───────────────┼────────┤
  │ prove_sumcheck_ext_i │ 4.369 s   │ 6.575 s       │ +50%   │
  │ n_place              │           │               │        │
  └──────────────────────┴───────────┴───────────────┴────────┘
```
## Memory

In the case of proving $s = \sum_b \prod_i f_i(b)$ where each $f_i$ has 25 or 26 variables, the peak memory using this new method is reduced **by half**.

cmd: `cargo bench --package sumcheck memory_usage`.
```
nv       mode                               min (MB)     max (MB)  median (MB)
--------------------------------------------------------------------------------
25       LegacyStable                          768.0        768.0        768.0
25       ReducedPeakMemory                     384.0        384.0        384.0

26       LegacyStable                         1536.0       1536.0       1536.0
26       ReducedPeakMemory                     768.0        768.0        768.0
```