### PR TITLE
Support compact default-padded MLEs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,12 @@ When reviewing a PR/diff, respond in this order:
 
 **Do not commit, push, or propose code changes.** Provide review comments and findings only; authors will implement fixes.
 
+Prefer line-level review comments over an overall summary:
+
+- For each actionable finding, attach an inline comment to the most relevant changed line when the review surface supports inline comments.
+- If inline comments are not supported in the current surface, include an explicit location in the finding header as `path:line` and symbol.
+- Do not return summary-only reviews when actionable findings exist.
+
 Before reviewing code, check PR metadata:
 
 - Verify the pull request description is non-empty.
@@ -41,6 +47,7 @@ For each finding:
 - Explain impact (what can break and under what conditions).
 - Propose a concrete fix or mitigation.
 - Mention what test would catch it if no test currently covers it.
+- Keep one finding per location; split multi-location issues into separate findings.
 
 If there are no findings, say that explicitly and note residual risk/testing gaps.
 

--- a/crates/multilinear_extensions/src/expression.rs
+++ b/crates/multilinear_extensions/src/expression.rs
@@ -1280,7 +1280,8 @@ pub fn wit_infer_by_monomial_expr<'a, E: ExtensionField>(
         })
         .collect();
 
-    MultilinearExtension::from_evaluation_vec_smart(witness[0].num_vars(), evaluations).into()
+    MultilinearExtension::from_evaluation_vec_smart_compact(witness[0].num_vars(), evaluations)
+        .into()
 }
 
 /// infer witness value from expression by flattening into monomial terms

--- a/crates/multilinear_extensions/src/mle.rs
+++ b/crates/multilinear_extensions/src/mle.rs
@@ -320,16 +320,6 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         );
     }
 
-    #[inline(always)]
-    fn compact_fold_len(len: usize) -> usize {
-        (len + 1) >> 1
-    }
-
-    #[inline(always)]
-    fn compact_fold_len_two_vars(len: usize) -> usize {
-        (len + 3) >> 2
-    }
-
     /// Returns `Right(&mut self)` if mutable access is possible, otherwise `Left(&self)`
     pub fn to_either(&mut self) -> Either<&Self, &mut Self> {
         if self.is_mut() {
@@ -654,7 +644,7 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
                 }
                 FieldType::Unreachable => unreachable!(),
             };
-            new_len = Self::compact_fold_len(new_len);
+            new_len = new_len.div_ceil(2);
         }
         match &mut self.evaluations {
             FieldType::Base(_) => unreachable!(),
@@ -800,7 +790,7 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
             FieldType::Ext(slice) => {
                 let slice_mut = slice.to_mut();
                 let quad_len = largest_multiple_of_four_below(slice_mut.len());
-                let new_len = Self::compact_fold_len_two_vars(slice_mut.len());
+                let new_len = slice_mut.len().div_ceil(4);
                 for i in 0..(quad_len >> 2) {
                     let b = i << 2;
                     slice_mut[i] = Self::eval_block_2_vars_ext(&slice_mut[b..b + 4], r0, r1);
@@ -957,7 +947,7 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
                 }
                 FieldType::Unreachable => unreachable!(),
             };
-            new_len = Self::compact_fold_len(new_len);
+            new_len = new_len.div_ceil(2);
         }
         match &mut self.evaluations {
             FieldType::Base(_) => unreachable!(),

--- a/crates/multilinear_extensions/src/mle.rs
+++ b/crates/multilinear_extensions/src/mle.rs
@@ -5,7 +5,7 @@ use crate::{
     macros::{entered_span, exit_span},
     op_mle,
     smart_slice::SmartSlice,
-    util::ceil_log2,
+    util::{ceil_log2, largest_even_below, largest_multiple_of_four_below},
 };
 use either::Either;
 use ff_ext::{ExtensionField, FromUniformBytes};
@@ -308,6 +308,28 @@ macro_rules! split_eval_chunks {
 }
 
 impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
+    #[inline(always)]
+    fn assert_occupied_len(num_vars: usize, occupied_len: usize) {
+        let max_len = 1usize << num_vars;
+        assert!(
+            occupied_len > 0 && occupied_len <= max_len,
+            "occupied length {} exceeds logical length {} for num_vars {}",
+            occupied_len,
+            max_len,
+            num_vars
+        );
+    }
+
+    #[inline(always)]
+    fn compact_fold_len(len: usize) -> usize {
+        (len + 1) >> 1
+    }
+
+    #[inline(always)]
+    fn compact_fold_len_two_vars(len: usize) -> usize {
+        (len + 3) >> 2
+    }
+
     /// Returns `Right(&mut self)` if mutable access is possible, otherwise `Left(&self)`
     pub fn to_either(&mut self) -> Either<&Self, &mut Self> {
         if self.is_mut() {
@@ -346,8 +368,24 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         unimplemented!("type not support")
     }
 
+    pub fn from_evaluation_vec_smart_compact<T: Clone + 'static>(
+        num_vars: usize,
+        evaluations: Vec<T>,
+    ) -> Self {
+        if TypeId::of::<T>() == TypeId::of::<E>() {
+            return Self::from_evaluations_ext_vec_compact(num_vars, cast_vec(evaluations));
+        }
+
+        if TypeId::of::<T>() == TypeId::of::<E::BaseField>() {
+            return Self::from_evaluations_vec_compact(num_vars, cast_vec(evaluations));
+        }
+
+        unimplemented!("type not support")
+    }
+
     /// Create vector from field type
     pub fn from_field_type(num_vars: usize, field_type: FieldType<'a, E>) -> Self {
+        Self::assert_occupied_len(num_vars, field_type.len());
         Self {
             num_vars,
             evaluations: field_type,
@@ -356,6 +394,7 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
 
     /// Create vector from field type
     pub fn from_field_type_borrowed(num_vars: usize, field_type: &FieldType<'a, E>) -> Self {
+        Self::assert_occupied_len(num_vars, field_type.len());
         Self {
             num_vars,
             evaluations: field_type.as_borrowed_view(),
@@ -395,6 +434,15 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         }
     }
 
+    pub fn from_evaluations_vec_compact(num_vars: usize, evaluations: Vec<E::BaseField>) -> Self {
+        Self::assert_occupied_len(num_vars, evaluations.len());
+
+        Self {
+            num_vars,
+            evaluations: FieldType::Base(SmartSlice::Owned(evaluations)),
+        }
+    }
+
     /// Identical to [`from_evaluations_slice`], with and exception that evaluation vector is in
     /// extension field
     pub fn from_evaluations_ext_slice(num_vars: usize, evaluations: &'a [E]) -> Self {
@@ -419,6 +467,15 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
             1 << num_vars,
             "The size of evaluations should be 2^num_vars."
         );
+
+        Self {
+            num_vars,
+            evaluations: FieldType::Ext(SmartSlice::Owned(evaluations)),
+        }
+    }
+
+    pub fn from_evaluations_ext_vec_compact(num_vars: usize, evaluations: Vec<E>) -> Self {
+        Self::assert_occupied_len(num_vars, evaluations.len());
 
         Self {
             num_vars,
@@ -511,14 +568,38 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         for point in partial_point.iter() {
             match &mut poly {
                 poly @ Cow::Borrowed(_) => {
-                    *poly = op_mle!(self, |evaluations| {
-                        Cow::Owned(MultilinearExtension::from_evaluations_ext_vec(
-                            self.num_vars() - 1,
-                            evaluations
-                                .chunks(2)
-                                .map(|buf| *point * (buf[1] - buf[0]) + buf[0])
-                                .collect(),
-                        ))
+                    *poly = Cow::Owned(match self.evaluations() {
+                        FieldType::Base(evaluations) => {
+                            let pair_len = largest_even_below(evaluations.len());
+                            let mut folded = evaluations[..pair_len]
+                                .chunks_exact(2)
+                                .map(|buf| Self::eval_pair_base(buf[0], buf[1], *point))
+                                .collect::<Vec<_>>();
+                            if pair_len < evaluations.len() {
+                                folded
+                                    .push(Self::eval_pair_base_tail(evaluations[pair_len], *point));
+                            }
+                            MultilinearExtension::from_evaluations_ext_vec_compact(
+                                self.num_vars() - 1,
+                                folded,
+                            )
+                        }
+                        FieldType::Ext(evaluations) => {
+                            let pair_len = largest_even_below(evaluations.len());
+                            let mut folded = evaluations[..pair_len]
+                                .chunks_exact(2)
+                                .map(|buf| Self::eval_pair_ext(buf[0], buf[1], *point))
+                                .collect::<Vec<_>>();
+                            if pair_len < evaluations.len() {
+                                folded
+                                    .push(Self::eval_pair_ext_tail(evaluations[pair_len], *point));
+                            }
+                            MultilinearExtension::from_evaluations_ext_vec_compact(
+                                self.num_vars() - 1,
+                                folded,
+                            )
+                        }
+                        FieldType::Unreachable => unreachable!(),
                     });
                 }
                 Cow::Owned(poly) => poly.fix_variables_in_place(&[*point]),
@@ -539,16 +620,21 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
             self.num_vars()
         );
         let nv = self.num_vars();
+        let mut new_len = self.occupied_len();
         // evaluate single variable of partial point from left to right
         for point in partial_point.iter() {
             // override buf[b1, b2,..bt, 0] = (1-point) * buf[b1, b2,..bt, 0] + point * buf[b1,
             // b2,..bt, 1]
             match &mut self.evaluations {
                 FieldType::Base(slice) => {
-                    let slice_ext = slice
-                        .chunks(2)
-                        .map(|buf| *point * (buf[1] - buf[0]) + buf[0])
-                        .collect();
+                    let pair_len = largest_even_below(slice.len());
+                    let mut slice_ext = slice[..pair_len]
+                        .chunks_exact(2)
+                        .map(|buf| Self::eval_pair_base(buf[0], buf[1], *point))
+                        .collect::<Vec<_>>();
+                    if pair_len < slice.len() {
+                        slice_ext.push(Self::eval_pair_base_tail(slice[pair_len], *point));
+                    }
                     let _ = mem::replace(
                         &mut self.evaluations,
                         FieldType::Ext(SmartSlice::Owned(slice_ext)),
@@ -556,18 +642,24 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
                 }
                 FieldType::Ext(slice) => {
                     let slice_mut = slice.to_mut();
-                    (0..slice_mut.len()).step_by(2).for_each(|b| {
+                    let pair_len = largest_even_below(slice_mut.len());
+                    (0..pair_len).step_by(2).for_each(|b| {
                         slice_mut[b >> 1] =
                             slice_mut[b] + (slice_mut[b + 1] - slice_mut[b]) * *point
                     });
+                    if pair_len < slice_mut.len() {
+                        let lo = slice_mut[pair_len];
+                        slice_mut[pair_len >> 1] = lo + (E::ZERO - lo) * *point;
+                    }
                 }
                 FieldType::Unreachable => unreachable!(),
             };
+            new_len = Self::compact_fold_len(new_len);
         }
         match &mut self.evaluations {
             FieldType::Base(_) => unreachable!(),
             FieldType::Ext(slice) => {
-                slice.truncate_mut(1 << (nv - partial_point.len()));
+                slice.truncate_mut(new_len);
             }
             FieldType::Unreachable => unreachable!(),
         }
@@ -596,6 +688,48 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         y0 + (y1 - y0) * r1
     }
 
+    #[inline(always)]
+    fn eval_pair_base(lo: E::BaseField, hi: E::BaseField, point: E) -> E {
+        point * (hi - lo) + lo
+    }
+
+    #[inline(always)]
+    fn eval_pair_base_tail(lo: E::BaseField, point: E) -> E {
+        E::from_base(lo) + (E::ZERO - E::from_base(lo)) * point
+    }
+
+    #[inline(always)]
+    fn eval_pair_ext(lo: E, hi: E, point: E) -> E {
+        lo + (hi - lo) * point
+    }
+
+    #[inline(always)]
+    fn eval_pair_ext_tail(lo: E, point: E) -> E {
+        lo + (E::ZERO - lo) * point
+    }
+
+    #[inline(always)]
+    fn eval_block_2_vars_base_partial(block: &[E::BaseField], r0: E, r1: E) -> E {
+        let v0 = block.first().copied().map(E::from).unwrap_or(E::ZERO);
+        let v1 = block.get(1).copied().map(E::from).unwrap_or(E::ZERO);
+        let v2 = block.get(2).copied().map(E::from).unwrap_or(E::ZERO);
+        let v3 = block.get(3).copied().map(E::from).unwrap_or(E::ZERO);
+        let y0 = v0 + (v1 - v0) * r0;
+        let y1 = v2 + (v3 - v2) * r0;
+        y0 + (y1 - y0) * r1
+    }
+
+    #[inline(always)]
+    fn eval_block_2_vars_ext_partial(block: &[E], r0: E, r1: E) -> E {
+        let v0 = block.first().copied().unwrap_or(E::ZERO);
+        let v1 = block.get(1).copied().unwrap_or(E::ZERO);
+        let v2 = block.get(2).copied().unwrap_or(E::ZERO);
+        let v3 = block.get(3).copied().unwrap_or(E::ZERO);
+        let y0 = v0 + (v1 - v0) * r0;
+        let y1 = v2 + (v3 - v2) * r0;
+        y0 + (y1 - y0) * r1
+    }
+
     /// Reduce the number of variables by 2 in one pass.
     ///
     /// This avoids calling `fix_variables` twice and directly computes
@@ -604,20 +738,36 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         assert!(self.num_vars() >= 2, "num_vars {} < 2", self.num_vars());
         let nv = self.num_vars();
         match self.evaluations() {
-            FieldType::Base(slice) => MultilinearExtension::from_evaluations_ext_vec(
-                nv - 2,
-                slice
-                    .chunks(4)
+            FieldType::Base(slice) => {
+                let quad_len = largest_multiple_of_four_below(slice.len());
+                let mut folded = slice[..quad_len]
+                    .chunks_exact(4)
                     .map(|buf| Self::eval_block_2_vars_base(buf, r0, r1))
-                    .collect(),
-            ),
-            FieldType::Ext(slice) => MultilinearExtension::from_evaluations_ext_vec(
-                nv - 2,
-                slice
-                    .chunks(4)
+                    .collect::<Vec<_>>();
+                if quad_len < slice.len() {
+                    folded.push(Self::eval_block_2_vars_base_partial(
+                        &slice[quad_len..],
+                        r0,
+                        r1,
+                    ));
+                }
+                MultilinearExtension::from_evaluations_ext_vec_compact(nv - 2, folded)
+            }
+            FieldType::Ext(slice) => {
+                let quad_len = largest_multiple_of_four_below(slice.len());
+                let mut folded = slice[..quad_len]
+                    .chunks_exact(4)
                     .map(|buf| Self::eval_block_2_vars_ext(buf, r0, r1))
-                    .collect(),
-            ),
+                    .collect::<Vec<_>>();
+                if quad_len < slice.len() {
+                    folded.push(Self::eval_block_2_vars_ext_partial(
+                        &slice[quad_len..],
+                        r0,
+                        r1,
+                    ));
+                }
+                MultilinearExtension::from_evaluations_ext_vec_compact(nv - 2, folded)
+            }
             FieldType::Unreachable => unreachable!(),
         }
     }
@@ -630,10 +780,18 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
 
         match &mut self.evaluations {
             FieldType::Base(slice) => {
-                let ext_vec = slice
-                    .chunks(4)
+                let quad_len = largest_multiple_of_four_below(slice.len());
+                let mut ext_vec = slice[..quad_len]
+                    .chunks_exact(4)
                     .map(|buf| Self::eval_block_2_vars_base(buf, r0, r1))
-                    .collect();
+                    .collect::<Vec<_>>();
+                if quad_len < slice.len() {
+                    ext_vec.push(Self::eval_block_2_vars_base_partial(
+                        &slice[quad_len..],
+                        r0,
+                        r1,
+                    ));
+                }
                 let _ = std::mem::replace(
                     &mut self.evaluations,
                     FieldType::Ext(SmartSlice::Owned(ext_vec)),
@@ -641,10 +799,15 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
             }
             FieldType::Ext(slice) => {
                 let slice_mut = slice.to_mut();
-                let new_len = 1 << (nv - 2);
-                for i in 0..new_len {
+                let quad_len = largest_multiple_of_four_below(slice_mut.len());
+                let new_len = Self::compact_fold_len_two_vars(slice_mut.len());
+                for i in 0..(quad_len >> 2) {
                     let b = i << 2;
                     slice_mut[i] = Self::eval_block_2_vars_ext(&slice_mut[b..b + 4], r0, r1);
+                }
+                if quad_len < slice_mut.len() {
+                    slice_mut[quad_len >> 2] =
+                        Self::eval_block_2_vars_ext_partial(&slice_mut[quad_len..], r0, r1);
                 }
                 slice.truncate_mut(new_len);
             }
@@ -678,6 +841,18 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         self.num_vars
     }
 
+    pub fn occupied_len(&self) -> usize {
+        self.evaluations.len()
+    }
+
+    pub fn full_evaluation_len(&self) -> usize {
+        1 << self.num_vars
+    }
+
+    pub fn has_full_occupancy(&self) -> bool {
+        self.occupied_len() == self.full_evaluation_len()
+    }
+
     /// Reduce the number of variables of `self` by fixing the
     /// `partial_point.len()` variables at `partial_point`.
     pub fn fix_variables_parallel(&self, partial_point: &[E]) -> Self {
@@ -693,14 +868,38 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         for point in partial_point.iter() {
             match &mut poly {
                 poly @ Cow::Borrowed(_) => {
-                    *poly = op_mle!(self, |evaluations| {
-                        Cow::Owned(MultilinearExtension::from_evaluations_ext_vec(
-                            self.num_vars() - 1,
-                            evaluations
-                                .par_chunks(2)
-                                .map(|buf| *point * (buf[1] - buf[0]) + buf[0])
-                                .collect(),
-                        ))
+                    *poly = Cow::Owned(match self.evaluations() {
+                        FieldType::Base(evaluations) => {
+                            let pair_len = largest_even_below(evaluations.len());
+                            let mut folded = evaluations[..pair_len]
+                                .par_chunks_exact(2)
+                                .map(|buf| Self::eval_pair_base(buf[0], buf[1], *point))
+                                .collect::<Vec<_>>();
+                            if pair_len < evaluations.len() {
+                                folded
+                                    .push(Self::eval_pair_base_tail(evaluations[pair_len], *point));
+                            }
+                            MultilinearExtension::from_evaluations_ext_vec_compact(
+                                self.num_vars() - 1,
+                                folded,
+                            )
+                        }
+                        FieldType::Ext(evaluations) => {
+                            let pair_len = largest_even_below(evaluations.len());
+                            let mut folded = evaluations[..pair_len]
+                                .par_chunks_exact(2)
+                                .map(|buf| Self::eval_pair_ext(buf[0], buf[1], *point))
+                                .collect::<Vec<_>>();
+                            if pair_len < evaluations.len() {
+                                folded
+                                    .push(Self::eval_pair_ext_tail(evaluations[pair_len], *point));
+                            }
+                            MultilinearExtension::from_evaluations_ext_vec_compact(
+                                self.num_vars() - 1,
+                                folded,
+                            )
+                        }
+                        FieldType::Unreachable => unreachable!(),
                     });
                 }
                 Cow::Owned(poly) => poly.fix_variables_in_place_parallel(&[*point]),
@@ -721,16 +920,20 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
             self.num_vars()
         );
         let nv = self.num_vars();
+        let mut new_len = self.occupied_len();
         // evaluate single variable of partial point from left to right
-        for (i, point) in partial_point.iter().enumerate() {
-            let max_log2_size = nv - i;
+        for point in partial_point.iter() {
             // override buf[b1, b2,..bt, 0] = (1-point) * buf[b1, b2,..bt, 0] + point * buf[b1, b2,..bt, 1] in parallel
             match &mut self.evaluations {
                 FieldType::Base(slice) => {
-                    let slice_ext = slice
-                        .par_chunks(2)
-                        .map(|buf| *point * (buf[1] - buf[0]) + buf[0])
-                        .collect();
+                    let pair_len = largest_even_below(slice.len());
+                    let mut slice_ext = slice[..pair_len]
+                        .par_chunks_exact(2)
+                        .map(|buf| Self::eval_pair_base(buf[0], buf[1], *point))
+                        .collect::<Vec<_>>();
+                    if pair_len < slice.len() {
+                        slice_ext.push(Self::eval_pair_base_tail(slice[pair_len], *point));
+                    }
                     let _ = mem::replace(
                         &mut self.evaluations,
                         FieldType::Ext(SmartSlice::Owned(slice_ext)),
@@ -738,22 +941,28 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
                 }
                 FieldType::Ext(slice) => {
                     let slice_mut = slice.to_mut();
-                    slice_mut
+                    let pair_len = largest_even_below(slice_mut.len());
+                    slice_mut[..pair_len]
                         .par_chunks_mut(2)
                         .for_each(|buf| buf[0] = buf[0] + (buf[1] - buf[0]) * *point);
 
                     // sequentially update buf[b1, b2,..bt] = buf[b1, b2,..bt, 0]
-                    for index in 0..1 << (max_log2_size - 1) {
+                    for index in 0..(pair_len >> 1) {
                         slice_mut[index] = slice_mut[index << 1];
+                    }
+                    if pair_len < slice_mut.len() {
+                        let lo = slice_mut[pair_len];
+                        slice_mut[pair_len >> 1] = lo + (E::ZERO - lo) * *point;
                     }
                 }
                 FieldType::Unreachable => unreachable!(),
             };
+            new_len = Self::compact_fold_len(new_len);
         }
         match &mut self.evaluations {
             FieldType::Base(_) => unreachable!(),
             FieldType::Ext(slice) => {
-                slice.truncate_mut(1 << (nv - partial_point.len()));
+                slice.truncate_mut(new_len);
             }
             FieldType::Unreachable => unreachable!(),
         }

--- a/crates/multilinear_extensions/src/test.rs
+++ b/crates/multilinear_extensions/src/test.rs
@@ -1,12 +1,15 @@
 use ff_ext::{ExtensionField, FromUniformBytes};
-use p3::{field::extension::BinomialExtensionField, goldilocks::Goldilocks};
+use p3::{
+    field::{FieldAlgebra, extension::BinomialExtensionField},
+    goldilocks::Goldilocks,
+};
 use rand::thread_rng;
 
 type F = Goldilocks;
 type E = BinomialExtensionField<F, 2>;
 
 use crate::{
-    mle::{ArcMultilinearExtension, MultilinearExtension},
+    mle::{ArcMultilinearExtension, FieldType, MultilinearExtension},
     util::bit_decompose,
     virtual_poly::build_eq_x_r,
 };
@@ -20,6 +23,56 @@ fn test_eq_xr() {
         let eq_x_r2 = build_eq_x_r_for_test(r.as_ref());
         assert_eq!(eq_x_r, eq_x_r2);
     }
+}
+
+#[test]
+fn test_compact_fix_variables_matches_zero_padded() {
+    let eval = vec![
+        E::from_canonical_u32(3),
+        E::from_canonical_u32(5),
+        E::from_canonical_u32(7),
+        E::from_canonical_u32(11),
+        E::from_canonical_u32(13),
+    ];
+    let compact = MultilinearExtension::from_evaluations_ext_vec_compact(3, eval.clone());
+    let mut padded = eval;
+    padded.resize(1 << 3, E::ZERO);
+    let padded = MultilinearExtension::from_evaluations_ext_vec(3, padded);
+    let point = [E::from_canonical_u32(9)];
+
+    let compact_fixed = compact.fix_variables(&point);
+    let padded_fixed = padded.fix_variables(&point);
+    let compact_fixed_eval = match compact_fixed.evaluations() {
+        FieldType::Ext(values) => values.to_vec(),
+        value => panic!("unexpected field type {value:?}"),
+    };
+    let padded_fixed_eval = match padded_fixed.evaluations() {
+        FieldType::Ext(values) => values.to_vec(),
+        value => panic!("unexpected field type {value:?}"),
+    };
+    assert_eq!(
+        compact_fixed_eval,
+        padded_fixed_eval[..compact_fixed.occupied_len()]
+    );
+    assert_eq!(compact_fixed.num_vars(), padded_fixed.num_vars());
+
+    let r0 = E::from_canonical_u32(4);
+    let r1 = E::from_canonical_u32(6);
+    let compact_fixed_2 = compact.fix_two_variables(r0, r1);
+    let padded_fixed_2 = padded.fix_two_variables(r0, r1);
+    let compact_fixed_2_eval = match compact_fixed_2.evaluations() {
+        FieldType::Ext(values) => values.to_vec(),
+        value => panic!("unexpected field type {value:?}"),
+    };
+    let padded_fixed_2_eval = match padded_fixed_2.evaluations() {
+        FieldType::Ext(values) => values.to_vec(),
+        value => panic!("unexpected field type {value:?}"),
+    };
+    assert_eq!(
+        compact_fixed_2_eval,
+        padded_fixed_2_eval[..compact_fixed_2.occupied_len()]
+    );
+    assert_eq!(compact_fixed_2.num_vars(), padded_fixed_2.num_vars());
 }
 
 /// Naive method to build eq(x, r).

--- a/crates/multilinear_extensions/src/util.rs
+++ b/crates/multilinear_extensions/src/util.rs
@@ -35,6 +35,11 @@ pub fn largest_even_below(n: usize) -> usize {
     }
 }
 
+#[inline(always)]
+pub fn largest_multiple_of_four_below(n: usize) -> usize {
+    n & !3
+}
+
 fn prev_power_of_two(n: usize) -> usize {
     (n + 1).next_power_of_two() / 2
 }

--- a/crates/sumcheck/src/prover.rs
+++ b/crates/sumcheck/src/prover.rs
@@ -522,6 +522,30 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         }
     }
 
+    #[inline(always)]
+    fn mle_eval_round2_endpoints_partial(block: Either<&[E::BaseField], &[E]>, r0: E) -> (E, E) {
+        match block {
+            Either::Left(b) => {
+                let v0 = b.first().copied().map(E::from).unwrap_or(E::ZERO);
+                let v1 = b.get(1).copied().map(E::from).unwrap_or(E::ZERO);
+                let v2 = b.get(2).copied().map(E::from).unwrap_or(E::ZERO);
+                let v3 = b.get(3).copied().map(E::from).unwrap_or(E::ZERO);
+                let y0 = v0 + (v1 - v0) * r0;
+                let y1 = v2 + (v3 - v2) * r0;
+                (y0, y1 - y0)
+            }
+            Either::Right(b) => {
+                let v0 = b.first().copied().unwrap_or(E::ZERO);
+                let v1 = b.get(1).copied().unwrap_or(E::ZERO);
+                let v2 = b.get(2).copied().unwrap_or(E::ZERO);
+                let v3 = b.get(3).copied().unwrap_or(E::ZERO);
+                let y0 = v0 + (v1 - v0) * r0;
+                let y1 = v2 + (v3 - v2) * r0;
+                (y0, y1 - y0)
+            }
+        }
+    }
+
     /// Returns `(y0, dy)` where `y0 = fi(0, b)` and `dy = fi(1, b) - y0`,
     /// so that `fi(x, b) = y0 + dy * x` for any `x`.
     #[inline(always)]
@@ -539,6 +563,22 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         match block {
             Either::Left(b) => Self::mle_eval_round1_endpoints_base(b),
             Either::Right(b) => Self::mle_eval_round1_endpoints_ext(b),
+        }
+    }
+
+    #[inline(always)]
+    fn mle_eval_round1_endpoints_partial(block: Either<&[E::BaseField], &[E]>) -> (E, E) {
+        match block {
+            Either::Left(b) => {
+                let lo = b.first().copied().map(E::from).unwrap_or(E::ZERO);
+                let hi = b.get(1).copied().map(E::from).unwrap_or(E::ZERO);
+                (lo, hi - lo)
+            }
+            Either::Right(b) => {
+                let lo = b.first().copied().unwrap_or(E::ZERO);
+                let hi = b.get(1).copied().unwrap_or(E::ZERO);
+                (lo, hi - lo)
+            }
         }
     }
 
@@ -573,12 +613,26 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                             .map(|x| E::BaseField::from_canonical_u32(x as u32))
                             .collect();
                         let mut endpoints = vec![(E::ZERO, E::ZERO); degree];
-                        for b in (0..evals_len).step_by(4) {
+                        let quad_len = evals_len / 4 * 4;
+                        for b in (0..quad_len).step_by(4) {
                             for (k, &poly_idx) in prod.iter().enumerate() {
-                                endpoints[k] = Self::mle_eval_round2_endpoints(
-                                    f[poly_idx].as_ref().evaluations().as_slice(b..b + 4),
-                                    r0,
-                                );
+                                let block = f[poly_idx].as_ref().evaluations().as_slice(b..b + 4);
+                                endpoints[k] = Self::mle_eval_round2_endpoints(block, r0);
+                            }
+                            for (x, &x_felt) in x_felts.iter().enumerate() {
+                                uni_variate[x] += endpoints
+                                    .iter()
+                                    .map(|&(y0, dy)| y0 + dy * x_felt)
+                                    .product::<E>();
+                            }
+                        }
+                        if quad_len < evals_len {
+                            for (k, &poly_idx) in prod.iter().enumerate() {
+                                let block = f[poly_idx]
+                                    .as_ref()
+                                    .evaluations()
+                                    .as_slice(quad_len..evals_len);
+                                endpoints[k] = Self::mle_eval_round2_endpoints_partial(block, r0);
                             }
                             for (x, &x_felt) in x_felts.iter().enumerate() {
                                 uni_variate[x] += endpoints
@@ -598,11 +652,26 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                             .map(|x| E::BaseField::from_canonical_u32(x as u32))
                             .collect();
                         let mut endpoints = vec![(E::ZERO, E::ZERO); degree];
-                        for b in (0..evals_len).step_by(2) {
+                        let pair_len = largest_even_below(evals_len);
+                        for b in (0..pair_len).step_by(2) {
                             for (k, &poly_idx) in prod.iter().enumerate() {
-                                endpoints[k] = Self::mle_eval_round1_endpoints(
-                                    f[poly_idx].as_ref().evaluations().as_slice(b..b + 2),
-                                );
+                                let block = f[poly_idx].as_ref().evaluations().as_slice(b..b + 2);
+                                endpoints[k] = Self::mle_eval_round1_endpoints(block);
+                            }
+                            for (x, &x_felt) in x_felts.iter().enumerate() {
+                                uni_variate[x] += endpoints
+                                    .iter()
+                                    .map(|&(y0, dy)| y0 + dy * x_felt)
+                                    .product::<E>();
+                            }
+                        }
+                        if pair_len < evals_len {
+                            for (k, &poly_idx) in prod.iter().enumerate() {
+                                let block = f[poly_idx]
+                                    .as_ref()
+                                    .evaluations()
+                                    .as_slice(pair_len..evals_len);
+                                endpoints[k] = Self::mle_eval_round1_endpoints_partial(block);
                             }
                             for (x, &x_felt) in x_felts.iter().enumerate() {
                                 uni_variate[x] += endpoints

--- a/crates/sumcheck/src/test.rs
+++ b/crates/sumcheck/src/test.rs
@@ -6,7 +6,7 @@ use either::Either;
 use ff_ext::{BabyBearExt4, ExtensionField, FromUniformBytes, GoldilocksExt2};
 use itertools::Itertools;
 use multilinear_extensions::{
-    mle::Point,
+    mle::{MultilinearExtension, Point},
     monomial::Term,
     util::{ceil_log2, max_usable_threads},
     virtual_poly::{VPAuxInfo, VirtualPolynomial},
@@ -149,6 +149,54 @@ fn test_runtime_prover_modes_are_compatible_helper<E: ExtensionField>() {
     );
 
     assert_eq!(legacy_subclaim, reduced_subclaim);
+}
+
+#[test]
+fn test_compact_mle_matches_zero_padded_sumcheck() {
+    let eval = vec![
+        GoldilocksExt2::from_canonical_u32(2),
+        GoldilocksExt2::from_canonical_u32(3),
+        GoldilocksExt2::from_canonical_u32(5),
+        GoldilocksExt2::from_canonical_u32(7),
+        GoldilocksExt2::from_canonical_u32(11),
+    ];
+    let compact = MultilinearExtension::from_evaluations_ext_vec_compact(3, eval.clone());
+    let mut padded_eval = eval;
+    padded_eval.resize(1 << 3, GoldilocksExt2::ZERO);
+    let padded = MultilinearExtension::from_evaluations_ext_vec(3, padded_eval);
+
+    let compact_poly = VirtualPolynomials::new_from_monimials(
+        1,
+        3,
+        vec![Term {
+            scalar: Either::Right(GoldilocksExt2::ONE),
+            product: vec![Either::Left(&compact)],
+        }],
+    );
+    let padded_poly = VirtualPolynomials::new_from_monimials(
+        1,
+        3,
+        vec![Term {
+            scalar: Either::Right(GoldilocksExt2::ONE),
+            product: vec![Either::Left(&padded)],
+        }],
+    );
+
+    let mut compact_transcript = BasicTranscript::<GoldilocksExt2>::new(b"compact");
+    let (compact_proof, compact_state) =
+        IOPProverState::<GoldilocksExt2>::prove(compact_poly, &mut compact_transcript);
+
+    let mut padded_transcript = BasicTranscript::<GoldilocksExt2>::new(b"compact");
+    let (padded_proof, padded_state) =
+        IOPProverState::<GoldilocksExt2>::prove(padded_poly, &mut padded_transcript);
+
+    assert_eq!(compact_proof, padded_proof);
+    let compact_final = compact_state.get_mle_final_evaluations();
+    let padded_final = padded_state.get_mle_final_evaluations();
+    assert_eq!(compact_final.len(), padded_final.len());
+    for (compact_eval, padded_eval) in compact_final.iter().zip(padded_final.iter()) {
+        assert_eq!(compact_eval, &padded_eval[..compact_eval.len()]);
+    }
 }
 
 fn test_sumcheck<E: ExtensionField>(

--- a/crates/sumcheck_macro/src/lib.rs
+++ b/crates/sumcheck_macro/src/lib.rs
@@ -245,7 +245,7 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                             } else if x == 2 {
                                 quote! {-#v[b]}
                             } else {
-                                let scale = (x - 1) as u32;
+                                let scale = x - 1;
                                 quote! {-(#v[b] * E::BaseField::from_canonical_u32(#scale))}
                             }
                         })

--- a/crates/sumcheck_macro/src/lib.rs
+++ b/crates/sumcheck_macro/src/lib.rs
@@ -187,8 +187,6 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     // Generate AdditiveArray based on degree, for usage in match statement.
     let additive_converter = {
         let mut additive_array_items = TokenStream::new();
-        let mut additive_array_first_item = TokenStream::new();
-
         // Generate degree+1 row elements in AdditiveArray
         for i in 1..=(degree + 1) {
             let item = mul_exprs(
@@ -224,16 +222,40 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                     })
                     .collect(),
             );
-
-            if i == 1 {
-                additive_array_first_item = item.clone();
-            }
             additive_array_items = acc_list(additive_array_items, item);
         }
 
         let additive_array_items = quote! {
             #c_declarations
             AdditiveArray([#additive_array_items])
+        };
+
+        let tail_additive_array_items = {
+            let mut items = TokenStream::new();
+            for i in 1..=(degree + 1) {
+                let item = mul_exprs(
+                    (1..=degree)
+                        .map(|j: u32| {
+                            let v = ident(format!("v{j}"));
+                            let x = i - 1;
+                            if x == 0 {
+                                quote! {#v[b]}
+                            } else if x == 1 {
+                                quote! {#v[b] - #v[b]}
+                            } else if x == 2 {
+                                quote! {-#v[b]}
+                            } else {
+                                let scale = (x - 1) as u32;
+                                quote! {-(#v[b] * E::BaseField::from_canonical_u32(#scale))}
+                            }
+                        })
+                        .collect(),
+                );
+                items = acc_list(items, item);
+            }
+            quote! {
+                AdditiveArray([#items])
+            }
         };
 
         let iter = if parallalize {
@@ -321,14 +343,19 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                     } else {
                         if v1.len() == 1 {
                             let b = 0;
-                            AdditiveArray::<_, #degree_plus_one>([#additive_array_first_item ; #degree_plus_one])
+                            #tail_additive_array_items
                         } else {
-                            (0..largest_even_below(v1.len()))
+                            let mut sum = (0..largest_even_below(v1.len()))
                                 #iter
                                 .map(|b| {
                                     #additive_array_items
                                 })
-                                .sum::<AdditiveArray<_, #degree_plus_one>>()
+                                .sum::<AdditiveArray<_, #degree_plus_one>>();
+                            if !v1.len().is_multiple_of(2) {
+                                let b = v1.len() - 1;
+                                sum += #tail_additive_array_items;
+                            }
+                            sum
                         }
                     }
                 },

--- a/crates/witness/src/lib.rs
+++ b/crates/witness/src/lib.rs
@@ -240,20 +240,24 @@ impl<T: Sized + Sync + Clone + Send + Copy + Default + FieldAlgebra> RowMajorMat
         self.num_rows
     }
 
+    pub fn occupied_physical_rows(&self) -> usize {
+        self.num_instances() * Self::num_rotation(self.log2_num_rotation)
+    }
+
     fn num_rotation(log2_num_rotation: usize) -> usize {
         1 << log2_num_rotation
     }
 
     pub fn iter_rows(&self) -> Chunks<'_, T> {
         let num_rotation = Self::num_rotation(self.log2_num_rotation);
-        self.inner.values[..self.num_instances() * num_rotation * self.n_col()]
+        self.inner.values[..self.occupied_physical_rows() * self.n_col()]
             .chunks(num_rotation * self.inner.width)
     }
 
     pub fn iter_mut(&mut self) -> ChunksMut<'_, T> {
         self.invalidate_device_backing();
         let num_rotation = Self::num_rotation(self.log2_num_rotation);
-        let max_range = self.num_instances() * num_rotation * self.n_col();
+        let max_range = self.occupied_physical_rows() * self.n_col();
         self.inner.values[..max_range].chunks_mut(num_rotation * self.inner.width)
     }
 


### PR DESCRIPTION
## Problem

Backend MLE/sumcheck code assumed full logical-domain evaluation buffers, which blocks compact prover witnesses and wastes memory for sparse occupied domains.

## Approach

Add compact MLE constructors and fold/truncate behavior that preserve logical default padding semantics. Sumcheck can operate on compact occupied lengths while tests compare compact behavior against zero-padded full-domain results.

## Testing

```sh
# Covered by added multilinear extension and sumcheck regression tests in this PR.
# Integrated validation through ceno PR 1330:
cargo check --features gpu --package ceno_zkvm --bin e2e
RUST_LOG=error CENO_CONCURRENT_CHIP_PROVING=0 target/release/e2e --platform=ceno --max-cycle-per-shard=1000 --hints=2 --public-io=5 --shard-id=0 examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci
CENO_GPU_MEM_TRACKING=1 CENO_CONCURRENT_CHIP_PROVING=0 CENO_GPU_ENABLE_WITGEN=1 cargo run --config net.git-fetch-with-cli=true --release --package ceno_zkvm --features gpu --bin e2e -- --platform=ceno --max-cycle-per-shard=1600 examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
```

All integrated checks passed.

## Risk / Rollout

- Review focus: compact folding must be equivalent to full zero-padded logical-domain folding for odd lengths and variable fixing.
- Soundness risk is in shared backend arithmetic semantics; tests intentionally compare compact and padded behavior.
- Rollback: revert with companion compact GPU PRs in `ceno` and `ceno-gpu`.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.

- Perform review only; do not commit/push/propose code changes.
- Prefer inline comments on changed lines for each actionable finding.
- If inline comments are unavailable, use `[severity] path:line (symbol)` format.
- Prioritize soundness, performance, and architecture risks over style.
- Output order: findings by severity, then open questions, then brief summary.
- If PR description is empty or missing key context, report `PR metadata: description` as a finding.
