### PR TITLE
feat: assist sumcheck for jagged PCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,6 @@ dependencies = [
  "p3",
  "rand",
  "rand_chacha",
- "rayon",
  "serde",
  "sumcheck",
  "tracing",

--- a/crates/mpcs/Cargo.toml
+++ b/crates/mpcs/Cargo.toml
@@ -59,3 +59,7 @@ required-features = ["whir"]
 [[bench]]
 harness = false
 name = "jagged_sumcheck"
+
+[[bench]]
+harness = false
+name = "jagged_pcs"

--- a/crates/mpcs/Cargo.toml
+++ b/crates/mpcs/Cargo.toml
@@ -20,7 +20,6 @@ num-integer = "0.1"
 p3.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
-rayon = { workspace = true, optional = true }
 serde.workspace = true
 sumcheck.workspace = true
 tracing.workspace = true
@@ -34,7 +33,7 @@ tracing-forest = "0.1"
 
 [features]
 nightly-features = ["ff_ext/nightly-features"]
-parallel = ["p3/parallel", "dep:rayon"]
+parallel = ["p3/parallel"]
 whir = ["dep:whir"]
 print-trace = ["whir/print-trace"]
 sanity-check = []

--- a/crates/mpcs/benches/jagged_pcs.rs
+++ b/crates/mpcs/benches/jagged_pcs.rs
@@ -1,0 +1,169 @@
+use std::time::Duration;
+
+use criterion::*;
+use ff_ext::{FromUniformBytes, GoldilocksExt2};
+use mpcs::{
+    Basefold, BasefoldRSParams, PolynomialCommitmentScheme, SecurityLevel, jagged_batch_open,
+    jagged_commit,
+};
+use multilinear_extensions::{mle::MultilinearExtension, util::ceil_log2};
+use p3::{field::FieldAlgebra, goldilocks::Goldilocks, matrix::Matrix};
+use rand::{Rng, thread_rng};
+use transcript::BasicTranscript;
+use witness::{InstancePaddingStrategy, RowMajorMatrix};
+
+type E = GoldilocksExt2;
+type F = Goldilocks;
+type Pcs = Basefold<E, BasefoldRSParams>;
+
+const NUM_SAMPLES: usize = 10;
+const NUM_MATRICES: usize = 30;
+const NUM_COLS: usize = 32;
+
+fn make_rmm(num_rows: usize, num_cols: usize) -> RowMajorMatrix<F> {
+    let values: Vec<F> = (0..num_rows * num_cols)
+        .map(|i| F::from_canonical_u32(((i as u64 * 13 + 7) % (1 << 30)) as u32))
+        .collect();
+    RowMajorMatrix::<F>::new_by_values(values, num_cols, InstancePaddingStrategy::Default)
+}
+
+fn sample_heights(rng: &mut impl Rng, num_matrices: usize) -> Vec<usize> {
+    let log_range: Vec<usize> = (16..=22).collect();
+    (0..num_matrices)
+        .map(|_| 1usize << log_range[rng.gen_range(0..log_range.len())])
+        .collect()
+}
+
+fn eval_column_poly_at_point(col_evals: &[F], point: &[E]) -> E {
+    let s = point.len();
+    assert_eq!(col_evals.len(), 1 << s);
+    let mle = MultilinearExtension::from_evaluations_vec(s, col_evals.to_vec());
+    mle.evaluate(point)
+}
+
+fn bench_jagged_pcs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jagged_pcs");
+    group.sample_size(NUM_SAMPLES);
+
+    let mut rng = thread_rng();
+
+    let heights = sample_heights(&mut rng, NUM_MATRICES);
+    println!(
+        "Matrix heights (log2): {:?}",
+        heights.iter().map(|h| ceil_log2(*h)).collect::<Vec<_>>()
+    );
+
+    let rmms: Vec<_> = heights.iter().map(|&h| make_rmm(h, NUM_COLS)).collect();
+
+    let log_heights: Vec<usize> = rmms.iter().map(|rmm| ceil_log2(rmm.height())).collect();
+    let max_s = *log_heights.iter().max().unwrap();
+    let total_evals: usize = rmms.iter().map(|rmm| rmm.height() * rmm.width()).sum();
+    let num_giga_vars = ceil_log2(total_evals);
+    let num_polys = NUM_MATRICES * NUM_COLS;
+
+    println!(
+        "num_matrices={}, num_cols={}, num_polys={}, total_evals={}, num_giga_vars={}, max_s={}",
+        NUM_MATRICES, NUM_COLS, num_polys, total_evals, num_giga_vars, max_s
+    );
+
+    let poly_size = 1usize << num_giga_vars;
+    let param = Pcs::setup(poly_size, SecurityLevel::Conjecture100bits).unwrap();
+    let (pp, vp) = Pcs::trim(param, poly_size).unwrap();
+
+    // --- Bench commit ---
+    let comm = jagged_commit::<E, Pcs>(&pp, rmms.clone()).expect("commit failed");
+
+    group.bench_function(
+        BenchmarkId::new("commit", format!("{}x{}", NUM_MATRICES, NUM_COLS)),
+        |b| {
+            b.iter_custom(|iters| {
+                let mut time = Duration::new(0, 0);
+                for _ in 0..iters {
+                    let rmms_clone = rmms.clone();
+                    let instant = std::time::Instant::now();
+                    let _ = jagged_commit::<E, Pcs>(&pp, rmms_clone).unwrap();
+                    time += instant.elapsed();
+                }
+                time
+            })
+        },
+    );
+
+    // --- Prepare evaluation data ---
+    // Extract column polynomials (before bit-reversal) for computing true evaluations.
+    let col_polys: Vec<Vec<F>> = rmms
+        .iter()
+        .flat_map(|rmm| {
+            let h = rmm.height();
+            let w = rmm.width();
+            (0..w).map(move |c| (0..h).map(|r| rmm.values[r * w + c]).collect())
+        })
+        .collect();
+
+    let point: Vec<E> = (0..max_s).map(|_| E::random(&mut rng)).collect();
+
+    let evals: Vec<E> = col_polys
+        .iter()
+        .zip(
+            log_heights
+                .iter()
+                .flat_map(|&s| std::iter::repeat_n(s, NUM_COLS)),
+        )
+        .map(|(col, s_i)| eval_column_poly_at_point(col, &point[(max_s - s_i)..]))
+        .collect();
+
+    // --- Bench batch open ---
+    group.bench_function(
+        BenchmarkId::new("batch_open", format!("{}x{}", NUM_MATRICES, NUM_COLS)),
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut transcript = BasicTranscript::<E>::new(b"jagged_bench");
+                    Pcs::write_commitment(&comm.to_commitment().inner, &mut transcript).unwrap();
+                    transcript
+                },
+                |mut transcript| {
+                    jagged_batch_open::<E, Pcs>(&pp, &comm, &point, &evals, &mut transcript)
+                        .unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    // --- Bench batch verify ---
+    let mut transcript_p = BasicTranscript::<E>::new(b"jagged_bench");
+    Pcs::write_commitment(&comm.to_commitment().inner, &mut transcript_p).unwrap();
+    let proof = jagged_batch_open::<E, Pcs>(&pp, &comm, &point, &evals, &mut transcript_p).unwrap();
+    let pure_comm = comm.to_commitment();
+
+    group.bench_function(
+        BenchmarkId::new("batch_verify", format!("{}x{}", NUM_MATRICES, NUM_COLS)),
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut transcript = BasicTranscript::<E>::new(b"jagged_bench");
+                    Pcs::write_commitment(&pure_comm.inner, &mut transcript).unwrap();
+                    transcript
+                },
+                |mut transcript| {
+                    mpcs::jagged_batch_verify::<E, Pcs>(
+                        &vp,
+                        &pure_comm,
+                        &point,
+                        &evals,
+                        &proof,
+                        &mut transcript,
+                    )
+                    .unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_jagged_pcs);
+criterion_main!(benches);

--- a/crates/mpcs/benches/jagged_sumcheck.rs
+++ b/crates/mpcs/benches/jagged_sumcheck.rs
@@ -68,7 +68,7 @@ fn bench_assist_sumcheck(c: &mut Criterion) {
     let poly_height_log2 = 20usize;
     let poly_height = 1usize << poly_height_log2;
 
-    for num_polys in [1000, 2000, 4000, 8000] {
+    for num_polys in [1000, 2000, 4000, 8000, 16000] {
         let mut rng = thread_rng();
 
         let total_evals = num_polys * poly_height;

--- a/crates/mpcs/benches/jagged_sumcheck.rs
+++ b/crates/mpcs/benches/jagged_sumcheck.rs
@@ -1,7 +1,7 @@
 use criterion::*;
 use ff_ext::{BabyBearExt4, ExtensionField, FieldFrom, FromUniformBytes};
-use mpcs::{JaggedSumcheckInput, jagged_sumcheck_prove};
-use multilinear_extensions::virtual_poly::build_eq_x_r_vec;
+use mpcs::{JaggedSumcheckInput, assist_sumcheck_prove, jagged_sumcheck_prove};
+use multilinear_extensions::{util::ceil_log2, virtual_poly::build_eq_x_r_vec};
 use rand::thread_rng;
 use transcript::BasicTranscript;
 
@@ -61,5 +61,45 @@ fn bench_jagged_sumcheck(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_jagged_sumcheck);
+fn bench_assist_sumcheck(c: &mut Criterion) {
+    let mut group = c.benchmark_group("assist_sumcheck");
+    group.sample_size(NUM_SAMPLES);
+
+    let poly_height_log2 = 20usize;
+    let poly_height = 1usize << poly_height_log2;
+
+    for num_polys in [100, 500, 1000] {
+        let mut rng = thread_rng();
+
+        let total_evals = num_polys * poly_height;
+        let num_giga_vars = ceil_log2(total_evals);
+        let n_robp = num_giga_vars + if total_evals.is_power_of_two() { 1 } else { 0 };
+
+        let cumulative_heights: Vec<usize> = (0..=num_polys).map(|i| i * poly_height).collect();
+
+        let z_row: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let rho: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let num_col_vars = ceil_log2(num_polys).max(1);
+        let z_col: Vec<E> = (0..num_col_vars).map(|_| E::random(&mut rng)).collect();
+        let eq_col = build_eq_x_r_vec(&z_col);
+
+        group.bench_function(BenchmarkId::new("prove", format!("K={}", num_polys)), |b| {
+            b.iter(|| {
+                let mut transcript = BasicTranscript::<E>::new(b"assist_bench");
+                assist_sumcheck_prove(
+                    black_box(&z_row),
+                    black_box(&rho),
+                    black_box(&eq_col),
+                    black_box(&cumulative_heights),
+                    black_box(n_robp),
+                    &mut transcript,
+                )
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_jagged_sumcheck, bench_assist_sumcheck);
 criterion_main!(benches);

--- a/crates/mpcs/benches/jagged_sumcheck.rs
+++ b/crates/mpcs/benches/jagged_sumcheck.rs
@@ -68,7 +68,7 @@ fn bench_assist_sumcheck(c: &mut Criterion) {
     let poly_height_log2 = 20usize;
     let poly_height = 1usize << poly_height_log2;
 
-    for num_polys in [100, 500, 1000] {
+    for num_polys in [1000, 2000, 4000, 8000] {
         let mut rng = thread_rng();
 
         let total_evals = num_polys * poly_height;

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -94,7 +94,13 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         let r_cd: [StateVec<E>; 4] = std::array::from_fn(|cd| vec_mat_mul(&fwd, &step_mats[i][cd]));
 
         // ---- Round 2i: bind z₃[i] ----
-        // Group backward vectors by (c, d) pair, weighted.
+        //
+        // Key identity (§2.3, Eq. 4): because x_y is Boolean, the MLE
+        // telescoping property  Σ_b f(b)·eq(b, x) = f(x)  collapses the
+        // sum over future variables.  Each polynomial y contributes a single
+        // backward vector bwd[y][i+1] (evaluated along its Boolean suffix)
+        // rather than an exponential sum.  We group these by (c,d) symbol
+        // so that the fwd·M^{(c,d)} precomputation can be shared.
         let mut bwd_sum = [[E::ZERO; ROBP_WIDTH]; 4];
         for y in 0..num_polys {
             let cd = c_bits[y][i] * 2 + d_bits[y][i];

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -12,7 +12,7 @@
 //! each pair of consecutive sumcheck rounds maps to one ROBP step.
 
 use ff_ext::ExtensionField;
-use p3::maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use p3::maybe_rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use sumcheck::structs::{IOPProof, IOPProverMessage};
 use transcript::Transcript;
 
@@ -47,39 +47,34 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         .map(|i| symbol_transition_matrices(z_row_padded[i], rho_padded[i]))
         .collect();
 
-    // Extract Boolean bits for each polynomial's evaluation points.
-    // x_y = interleaved (c_y[0], d_y[0], c_y[1], d_y[1], ...)
-    // c_y[i] = bit_i(t_y), d_y[i] = bit_i(t_{y+1})
-    let c_bits: Vec<Vec<usize>> = (0..num_polys)
-        .map(|y| {
-            (0..n_robp)
-                .map(|i| (cumulative_heights[y] >> i) & 1)
-                .collect()
-        })
-        .collect();
-    let d_bits: Vec<Vec<usize>> = (0..num_polys)
-        .map(|y| {
-            (0..n_robp)
-                .map(|i| (cumulative_heights[y + 1] >> i) & 1)
-                .collect()
-        })
-        .collect();
+    // Extract Boolean bits in step-major layout: c_bits[i][y], d_bits[i][y].
+    // c_bits[i][y] = bit_i(t_y), d_bits[i][y] = bit_i(t_{y+1})
+    let mut c_bits = vec![vec![0usize; num_polys]; n_robp];
+    let mut d_bits = vec![vec![0usize; num_polys]; n_robp];
+    for i in 0..n_robp {
+        for y in 0..num_polys {
+            c_bits[i][y] = (cumulative_heights[y] >> i) & 1;
+            d_bits[i][y] = (cumulative_heights[y + 1] >> i) & 1;
+        }
+    }
 
-    // Precompute backward vectors: bwd[y][i] for i ∈ [0, n_robp].
-    // bwd[y][n] = sink_labels, bwd[y][i] = M_i^{(c,d)} · bwd[y][i+1]
+    // Precompute backward vectors in step-major layout bwd[i][y].
+    // Outer loop over steps (sequential, reversed); inner loop over K
+    // polynomials (parallel). Both reads and writes are contiguous.
     let u = sink_labels::<E>();
-    let bwd: Vec<Vec<StateVec<E>>> = (0..num_polys)
-        .into_par_iter()
-        .map(|y| {
-            let mut vecs = vec![[E::ZERO; ROBP_WIDTH]; n_robp + 1];
-            vecs[n_robp] = u;
-            for i in (0..n_robp).rev() {
-                let cd = c_bits[y][i] * 2 + d_bits[y][i];
-                vecs[i] = mat_vec_mul(&step_mats[i][cd], &vecs[i + 1]);
-            }
-            vecs
-        })
-        .collect();
+    let mut bwd = vec![vec![[E::ZERO; ROBP_WIDTH]; num_polys]; n_robp + 1];
+    for y in 0..num_polys {
+        bwd[n_robp][y] = u;
+    }
+    for i in (0..n_robp).rev() {
+        let (left, right) = bwd.split_at_mut(i + 1);
+        let dst = &mut left[i];
+        let src = &right[0];
+        dst.into_par_iter().enumerate().for_each(|(y, dst_y)| {
+            let cd = c_bits[i][y] * 2 + d_bits[i][y];
+            *dst_y = mat_vec_mul(&step_mats[i][cd], &src[y]);
+        });
+    }
 
     // Initialize weights and forward vector.
     let mut weights: Vec<E> = eq_col[..num_polys].to_vec();
@@ -95,18 +90,21 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
 
         // ---- Round 2i: bind z₃[i] ----
         //
-        // Key identity (§2.3, Eq. 4): because x_y is Boolean, the MLE
-        // telescoping property  Σ_b f(b)·eq(b, x) = f(x)  collapses the
-        // sum over future variables.  Each polynomial y contributes a single
-        // backward vector bwd[y][i+1] (evaluated along its Boolean suffix)
-        // rather than an exponential sum.  We group these by (c,d) symbol
-        // so that the fwd·M^{(c,d)} precomputation can be shared.
+        // Round polynomial (§2.3, Eq. 4):
+        //   p_{2i}(λ) = Σ_{c,d} eq₁(λ,c) · fwd·T_half(λ,d) · bwd_sum[c*2+d]
+        // where
+        //   bwd_sum[c*2+d] = Σ_{y: c_y[i]=c, d_y[i]=d} w_y · bwd_{i+1}^{(y)}
+        //
+        // The MLE telescoping property (Σ_b f(b)·eq(b,x) = f(x) for Boolean x)
+        // collapses the sum over future variables, so each polynomial y
+        // contributes a single backward vector bwd[i+1][y]. Grouping by (c,d)
+        // turns K terms into 4 buckets, letting fwd·M^{(c,d)} be shared.
         let mut bwd_sum = [[E::ZERO; ROBP_WIDTH]; 4];
         for y in 0..num_polys {
-            let cd = c_bits[y][i] * 2 + d_bits[y][i];
+            let cd = c_bits[i][y] * 2 + d_bits[i][y];
             let w = weights[y];
             for s in 0..ROBP_WIDTH {
-                bwd_sum[cd][s] += w * bwd[y][i + 1][s];
+                bwd_sum[cd][s] += w * bwd[i + 1][y][s];
             }
         }
 
@@ -181,7 +179,7 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         let nb = E::ONE - beta;
         let eq_cd = [na * nb, na * beta, alpha * nb, alpha * beta];
         for y in 0..num_polys {
-            let cd = c_bits[y][i] * 2 + d_bits[y][i];
+            let cd = c_bits[i][y] * 2 + d_bits[i][y];
             weights[y] *= eq_cd[cd];
         }
 

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -12,6 +12,7 @@
 //! each pair of consecutive sumcheck rounds maps to one ROBP step.
 
 use ff_ext::ExtensionField;
+use p3::maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use sumcheck::structs::{IOPProof, IOPProverMessage};
 use transcript::Transcript;
 
@@ -67,16 +68,18 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
     // Precompute backward vectors: bwd[y][i] for i ∈ [0, n_robp].
     // bwd[y][n] = sink_labels, bwd[y][i] = M_i^{(c,d)} · bwd[y][i+1]
     let u = sink_labels::<E>();
-    let mut bwd: Vec<Vec<StateVec<E>>> = Vec::with_capacity(num_polys);
-    for y in 0..num_polys {
-        let mut vecs = vec![[E::ZERO; ROBP_WIDTH]; n_robp + 1];
-        vecs[n_robp] = u;
-        for i in (0..n_robp).rev() {
-            let cd = c_bits[y][i] * 2 + d_bits[y][i];
-            vecs[i] = mat_vec_mul(&step_mats[i][cd], &vecs[i + 1]);
-        }
-        bwd.push(vecs);
-    }
+    let bwd: Vec<Vec<StateVec<E>>> = (0..num_polys)
+        .into_par_iter()
+        .map(|y| {
+            let mut vecs = vec![[E::ZERO; ROBP_WIDTH]; n_robp + 1];
+            vecs[n_robp] = u;
+            for i in (0..n_robp).rev() {
+                let cd = c_bits[y][i] * 2 + d_bits[y][i];
+                vecs[i] = mat_vec_mul(&step_mats[i][cd], &vecs[i + 1]);
+            }
+            vecs
+        })
+        .collect();
 
     // Initialize weights and forward vector.
     let mut weights: Vec<E> = eq_col[..num_polys].to_vec();
@@ -133,22 +136,14 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
             evaluations: vec![p1, p2],
         });
 
-        // Update weights: w_y *= eq₁(α, c_y[i])
-        let na = E::ONE - alpha;
-        for y in 0..num_polys {
-            weights[y] *= if c_bits[y][i] == 0 { na } else { alpha };
-        }
-
         // ---- Round 2i+1: bind z₄[i] ----
-        // Group by d only (c is already absorbed into weights).
-        let mut bwd_sum_d = [[E::ZERO; ROBP_WIDTH]; 2];
-        for y in 0..num_polys {
-            let d = d_bits[y][i];
-            let w = weights[y];
-            for s in 0..ROBP_WIDTH {
-                bwd_sum_d[d][s] += w * bwd[y][i + 1][s];
-            }
-        }
+        // Derive bwd_sum_d from bwd_sum: absorb eq₁(α, c) without a second O(K) pass.
+        // bwd_sum_d[d] = (1-α)·bwd_sum[(c=0,d)] + α·bwd_sum[(c=1,d)]
+        let na = E::ONE - alpha;
+        let bwd_sum_d: [[E; ROBP_WIDTH]; 2] = [
+            std::array::from_fn(|s| na * bwd_sum[0][s] + alpha * bwd_sum[2][s]),
+            std::array::from_fn(|s| na * bwd_sum[1][s] + alpha * bwd_sum[3][s]),
+        ];
 
         // fwd · T_full(α, λ) at λ=0: (1-α)·R_{0,0} + α·R_{1,0}
         let row_at_0: StateVec<E> = std::array::from_fn(|j| na * r_cd[0][j] + alpha * r_cd[2][j]);
@@ -176,18 +171,20 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
             evaluations: vec![p1, p2],
         });
 
-        // Update weights: w_y *= eq₁(β, d_y[i])
+        // Fused weight update: w_y *= eq₁(α, c_y[i]) · eq₁(β, d_y[i])
         let nb = E::ONE - beta;
+        let eq_cd = [na * nb, na * beta, alpha * nb, alpha * beta];
         for y in 0..num_polys {
-            weights[y] *= if d_bits[y][i] == 0 { nb } else { beta };
+            let cd = c_bits[y][i] * 2 + d_bits[y][i];
+            weights[y] *= eq_cd[cd];
         }
 
         // Update forward vector: fwd ← fwd · T_full(α, β)
         fwd = std::array::from_fn(|j| {
-            na * nb * r_cd[0][j]
-                + na * beta * r_cd[1][j]
-                + alpha * nb * r_cd[2][j]
-                + alpha * beta * r_cd[3][j]
+            eq_cd[0] * r_cd[0][j]
+                + eq_cd[1] * r_cd[1][j]
+                + eq_cd[2] * r_cd[2][j]
+                + eq_cd[3] * r_cd[3][j]
         });
     }
 

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -13,11 +13,7 @@
 
 use ff_ext::ExtensionField;
 use multilinear_extensions::util::max_usable_threads;
-#[cfg(feature = "parallel")]
-use p3::maybe_rayon::prelude::IndexedParallelIterator;
-use p3::maybe_rayon::prelude::{
-    IntoParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut,
-};
+use p3::maybe_rayon::prelude::*;
 use sumcheck::structs::{IOPProof, IOPProverMessage};
 use transcript::Transcript;
 

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -12,7 +12,11 @@
 //! each pair of consecutive sumcheck rounds maps to one ROBP step.
 
 use ff_ext::ExtensionField;
-use p3::maybe_rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use multilinear_extensions::util::max_usable_threads;
+use p3::maybe_rayon::prelude::{
+    IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSlice,
+    ParallelSliceMut,
+};
 use sumcheck::structs::{IOPProof, IOPProverMessage};
 use transcript::Transcript;
 
@@ -58,9 +62,26 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         }
     }
 
-    // Precompute backward vectors in step-major layout bwd[i][y].
-    // Outer loop over steps (sequential, reversed); inner loop over K
-    // polynomials (parallel). Both reads and writes are contiguous.
+    // Precompute backward vectors bwd[i][y] (step-major layout).
+    //
+    // bwd[i][y] is a 4-element state vector representing the ROBP suffix
+    // product from step i to the sinks, for polynomial y's Boolean bits:
+    //
+    //   bwd[n][y]  = u = [0, 1, 0, 0]          (sink labels: accept at carry=0, lt=1)
+    //   bwd[i][y]  = M_i^{(c_y[i], d_y[i])} · bwd[i+1][y],   i = n-1, …, 0
+    //
+    // where c_y[i] = bit_i(t_y), d_y[i] = bit_i(t_{y+1}), and M_i^{(c,d)}
+    // is the per-symbol transition matrix with z_row[i], ρ[i] baked in.
+    //
+    // The full ROBP evaluation for polynomial y equals:
+    //   ĝ(z_row, ρ, bits(t_y), bits(t_{y+1})) = e_0^T · bwd[0][y]
+    //
+    // During the sumcheck, the prover decomposes ĝ into fwd · bwd.
+    // M_i^{(c,d)} extends to field arguments via MLE: M_i^{(α,β)} means
+    // Σ_{c,d} eq₁(α,c)·eq₁(β,d)·M_i^{(c,d)}.  With this notation:
+    //   round 2i:   h_y(λ) = fwd · M_i^{(λ, d_y[i])} · bwd[i+1][y]
+    //   round 2i+1: h_y(λ) = fwd · M_i^{(α, λ)}      · bwd[i+1][y]
+    // where fwd absorbs bound challenges and bwd provides the Boolean suffix.
     let u = sink_labels::<E>();
     let mut bwd = vec![vec![[E::ZERO; ROBP_WIDTH]; num_polys]; n_robp + 1];
     for y in 0..num_polys {
@@ -83,41 +104,74 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
     let mut challenges: Vec<E> = Vec::with_capacity(n_vars);
     let mut proof_messages: Vec<IOPProverMessage<E>> = Vec::with_capacity(n_vars);
 
-    #[allow(clippy::needless_range_loop)]
+    let n_threads = max_usable_threads();
+    let poly_indices: Vec<usize> = (0..num_polys).collect();
+
     for i in 0..n_robp {
         // Precompute fwd · M^{(c,d)} for all 4 symbols.
         let r_cd: [StateVec<E>; 4] = std::array::from_fn(|cd| vec_mat_mul(&fwd, &step_mats[i][cd]));
 
         // ---- Round 2i: bind z₃[i] ----
         //
-        // Round polynomial (§2.3, Eq. 4):
-        //   p_{2i}(λ) = Σ_{c,d} eq₁(λ,c) · fwd·T_half(λ,d) · bwd_sum[c*2+d]
-        // where
-        //   bwd_sum[c*2+d] = Σ_{y: c_y[i]=c, d_y[i]=d} w_y · bwd_{i+1}^{(y)}
+        // Round polynomial for round 2i:
+        //   p_{2i}(λ) = Σ_y w_y · eq₁(λ, c_y[i]) · fwd · M_i^{(λ, d_y[i])} · bwd[i+1][y]
         //
-        // The MLE telescoping property (Σ_b f(b)·eq(b,x) = f(x) for Boolean x)
-        // collapses the sum over future variables, so each polynomial y
-        // contributes a single backward vector bwd[i+1][y]. Grouping by (c,d)
-        // turns K terms into 4 buckets, letting fwd·M^{(c,d)} be shared.
-        let mut bwd_sum = [[E::ZERO; ROBP_WIDTH]; 4];
-        for y in 0..num_polys {
-            let cd = c_bits[i][y] * 2 + d_bits[i][y];
-            let w = weights[y];
-            for s in 0..ROBP_WIDTH {
-                bwd_sum[cd][s] += w * bwd[i + 1][y][s];
-            }
-        }
-
-        // p(0): eq₁(0,c=0)=1, eq₁(0,c=1)=0. fwd_row(0,d) = R_{0,d}.
-        let p0 = dot4(&r_cd[0], &bwd_sum[0]) + dot4(&r_cd[1], &bwd_sum[1]);
-        // p(1): eq₁(1,c=0)=0, eq₁(1,c=1)=1. fwd_row(1,d) = R_{1,d}.
-        let p1 = dot4(&r_cd[2], &bwd_sum[2]) + dot4(&r_cd[3], &bwd_sum[3]);
-        // p(2): eq₁(2,c=0)=-1, eq₁(2,c=1)=2. fwd_row(2,d) = 2·R_{1,d} - R_{0,d}.
+        // Precompute R[c*2+d] = fwd · M_i^{(c,d)} as row-vectors for Boolean (c,d).
+        // Then fwd · M_i^{(λ,d)} = (1-λ)·R[d] + λ·R[2+d] is also a row-vector,
+        // so each term reduces to a dot product with bwd — no matrix-vector multiply.
+        //
+        // Expanding M_i^{(λ,d)} = Σ_{c'} eq₁(λ,c')·M_i^{(c',d)} in the bucketed form:
+        //   p_{2i}(λ) = Σ_{c,c',d} eq₁(λ,c) · eq₁(λ,c') · R[c'*2+d] · bwd_sum[c*2+d]
+        // where c indexes the Q bucket and c' indexes the M expansion (independent).
+        //
+        // Bucket bwd vectors by (c,d):
+        //   bwd_sum[c*2+d] = Σ_{y: c_y[i]=c, d_y[i]=d} w_y · bwd[i+1][y]
+        //
+        // This reduces evaluation at each λ to 4 dot products against bwd_sum.
+        //
+        // Parallelization: partition K polynomials across threads. Each thread
+        // builds local bwd_sum, computes local (p0, p1, p2), then we sum
+        // the scalars across threads. We also merge bwd_sum for round 2i+1.
         let row2_d0: StateVec<E> = std::array::from_fn(|j| r_cd[2][j].double() - r_cd[0][j]);
         let row2_d1: StateVec<E> = std::array::from_fn(|j| r_cd[3][j].double() - r_cd[1][j]);
-        let term_c0 = dot4(&row2_d0, &bwd_sum[0]) + dot4(&row2_d1, &bwd_sum[1]);
-        let term_c1 = dot4(&row2_d0, &bwd_sum[2]) + dot4(&row2_d1, &bwd_sum[3]);
-        let p2 = term_c1.double() - term_c0;
+
+        let batch_size = (num_polys / n_threads).max(1);
+        let partials: Vec<([E; 3], [[E; ROBP_WIDTH]; 4])> = poly_indices
+            .par_chunks(batch_size)
+            .map(|chunk| {
+                let mut local_bwd_sum = [[E::ZERO; ROBP_WIDTH]; 4];
+                for &y in chunk {
+                    let cd = c_bits[i][y] * 2 + d_bits[i][y];
+                    let w = weights[y];
+                    for s in 0..ROBP_WIDTH {
+                        local_bwd_sum[cd][s] += w * bwd[i + 1][y][s];
+                    }
+                }
+                let lp0 =
+                    dot4(&r_cd[0], &local_bwd_sum[0]) + dot4(&r_cd[1], &local_bwd_sum[1]);
+                let lp1 =
+                    dot4(&r_cd[2], &local_bwd_sum[2]) + dot4(&r_cd[3], &local_bwd_sum[3]);
+                let tc0 =
+                    dot4(&row2_d0, &local_bwd_sum[0]) + dot4(&row2_d1, &local_bwd_sum[1]);
+                let tc1 =
+                    dot4(&row2_d0, &local_bwd_sum[2]) + dot4(&row2_d1, &local_bwd_sum[3]);
+                let lp2 = tc1.double() - tc0;
+                ([lp0, lp1, lp2], local_bwd_sum)
+            })
+            .collect();
+
+        let mut bwd_sum = [[E::ZERO; ROBP_WIDTH]; 4];
+        let (mut p0, mut p1, mut p2) = (E::ZERO, E::ZERO, E::ZERO);
+        for (p_local, bs_local) in &partials {
+            p0 += p_local[0];
+            p1 += p_local[1];
+            p2 += p_local[2];
+            for cd in 0..4 {
+                for s in 0..ROBP_WIDTH {
+                    bwd_sum[cd][s] += bs_local[cd][s];
+                }
+            }
+        }
 
         debug_assert_eq!(
             p0 + p1,
@@ -141,15 +195,21 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         });
 
         // ---- Round 2i+1: bind z₄[i] ----
-        // Derive bwd_sum_d from bwd_sum: absorb eq₁(α, c) without a second O(K) pass.
-        // bwd_sum_d[d] = (1-α)·bwd_sum[(c=0,d)] + α·bwd_sum[(c=1,d)]
+        //
+        // Round polynomial for round 2i+1:
+        //   p_{2i+1}(λ) = Σ_y w_y · eq₁(λ, d_y[i]) · fwd · M_i^{(α, λ)} · bwd[i+1][y]
+        // where w_y logically includes eq₁(α, c_y[i]) from round 2i.
+        //
+        // Rather than an O(K) weight update, absorb eq₁(α, c) into the buckets:
+        //   bwd_sum_d[d] = Σ_c eq₁(α,c) · bwd_sum[c*2+d]
+        // collapsing 4 buckets into 2.
         let na = E::ONE - alpha;
         let bwd_sum_d: [[E; ROBP_WIDTH]; 2] = [
             std::array::from_fn(|s| na * bwd_sum[0][s] + alpha * bwd_sum[2][s]),
             std::array::from_fn(|s| na * bwd_sum[1][s] + alpha * bwd_sum[3][s]),
         ];
 
-        // fwd · T_full(α, λ) at λ=0: (1-α)·R_{0,0} + α·R_{1,0}
+        // fwd · M_i^{(α, λ)} at λ=0: (1-α)·R_{0,0} + α·R_{1,0}
         let row_at_0: StateVec<E> = std::array::from_fn(|j| na * r_cd[0][j] + alpha * r_cd[2][j]);
         // at λ=1: (1-α)·R_{0,1} + α·R_{1,1}
         let row_at_1: StateVec<E> = std::array::from_fn(|j| na * r_cd[1][j] + alpha * r_cd[3][j]);
@@ -178,12 +238,19 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         // Fused weight update: w_y *= eq₁(α, c_y[i]) · eq₁(β, d_y[i])
         let nb = E::ONE - beta;
         let eq_cd = [na * nb, na * beta, alpha * nb, alpha * beta];
-        for y in 0..num_polys {
-            let cd = c_bits[i][y] * 2 + d_bits[i][y];
-            weights[y] *= eq_cd[cd];
-        }
+        weights
+            .par_chunks_mut(batch_size)
+            .enumerate()
+            .for_each(|(chunk_idx, w_chunk)| {
+                let start = chunk_idx * batch_size;
+                for (j, w) in w_chunk.iter_mut().enumerate() {
+                    let y = start + j;
+                    let cd = c_bits[i][y] * 2 + d_bits[i][y];
+                    *w *= eq_cd[cd];
+                }
+            });
 
-        // Update forward vector: fwd ← fwd · T_full(α, β)
+        // Update forward vector: fwd ← fwd · M_i^{(α, β)}
         fwd = std::array::from_fn(|j| {
             eq_cd[0] * r_cd[0][j]
                 + eq_cd[1] * r_cd[1][j]

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -13,9 +13,10 @@
 
 use ff_ext::ExtensionField;
 use multilinear_extensions::util::max_usable_threads;
+#[cfg(feature = "parallel")]
+use p3::maybe_rayon::prelude::IndexedParallelIterator;
 use p3::maybe_rayon::prelude::{
-    IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSlice,
-    ParallelSliceMut,
+    IntoParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut,
 };
 use sumcheck::structs::{IOPProof, IOPProverMessage};
 use transcript::Transcript;
@@ -147,14 +148,10 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
                         local_bwd_sum[cd][s] += w * bwd[i + 1][y][s];
                     }
                 }
-                let lp0 =
-                    dot4(&r_cd[0], &local_bwd_sum[0]) + dot4(&r_cd[1], &local_bwd_sum[1]);
-                let lp1 =
-                    dot4(&r_cd[2], &local_bwd_sum[2]) + dot4(&r_cd[3], &local_bwd_sum[3]);
-                let tc0 =
-                    dot4(&row2_d0, &local_bwd_sum[0]) + dot4(&row2_d1, &local_bwd_sum[1]);
-                let tc1 =
-                    dot4(&row2_d0, &local_bwd_sum[2]) + dot4(&row2_d1, &local_bwd_sum[3]);
+                let lp0 = dot4(&r_cd[0], &local_bwd_sum[0]) + dot4(&r_cd[1], &local_bwd_sum[1]);
+                let lp1 = dot4(&r_cd[2], &local_bwd_sum[2]) + dot4(&r_cd[3], &local_bwd_sum[3]);
+                let tc0 = dot4(&row2_d0, &local_bwd_sum[0]) + dot4(&row2_d1, &local_bwd_sum[1]);
+                let tc1 = dot4(&row2_d0, &local_bwd_sum[2]) + dot4(&row2_d1, &local_bwd_sum[3]);
                 let lp2 = tc1.double() - tc0;
                 ([lp0, lp1, lp2], local_bwd_sum)
             })
@@ -166,15 +163,6 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
             p1 += p_local[1];
             p2 += p_local[2];
         }
-
-        debug_assert_eq!(
-            p0 + p1,
-            if i == 0 && challenges.is_empty() {
-                p0 + p1
-            } else {
-                p0 + p1
-            }
-        );
 
         transcript.append_field_element_ext(&p1);
         transcript.append_field_element_ext(&p2);

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -160,24 +160,16 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
             })
             .collect();
 
-        let mut bwd_sum = [[E::ZERO; ROBP_WIDTH]; 4];
         let (mut p0, mut p1, mut p2) = (E::ZERO, E::ZERO, E::ZERO);
-        for (p_local, bs_local) in &partials {
+        for (p_local, _) in &partials {
             p0 += p_local[0];
             p1 += p_local[1];
             p2 += p_local[2];
-            for cd in 0..4 {
-                for s in 0..ROBP_WIDTH {
-                    bwd_sum[cd][s] += bs_local[cd][s];
-                }
-            }
         }
 
         debug_assert_eq!(
             p0 + p1,
             if i == 0 && challenges.is_empty() {
-                // First round: p(0)+p(1) should equal the claimed_sum.
-                // We don't have claimed_sum here but can skip the check.
                 p0 + p1
             } else {
                 p0 + p1
@@ -200,15 +192,9 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         //   p_{2i+1}(λ) = Σ_y w_y · eq₁(λ, d_y[i]) · fwd · M_i^{(α, λ)} · bwd[i+1][y]
         // where w_y logically includes eq₁(α, c_y[i]) from round 2i.
         //
-        // Rather than an O(K) weight update, absorb eq₁(α, c) into the buckets:
-        //   bwd_sum_d[d] = Σ_c eq₁(α,c) · bwd_sum[c*2+d]
-        // collapsing 4 buckets into 2.
+        // Reuse cached per-thread bwd_sums from round 2i: each absorbs α to
+        // get local bwd_sum_d, computes local p(0), p(1), p(2), then we sum.
         let na = E::ONE - alpha;
-        let bwd_sum_d: [[E; ROBP_WIDTH]; 2] = [
-            std::array::from_fn(|s| na * bwd_sum[0][s] + alpha * bwd_sum[2][s]),
-            std::array::from_fn(|s| na * bwd_sum[1][s] + alpha * bwd_sum[3][s]),
-        ];
-
         // fwd · M_i^{(α, λ)} at λ=0: (1-α)·R_{0,0} + α·R_{1,0}
         let row_at_0: StateVec<E> = std::array::from_fn(|j| na * r_cd[0][j] + alpha * r_cd[2][j]);
         // at λ=1: (1-α)·R_{0,1} + α·R_{1,1}
@@ -216,14 +202,19 @@ pub fn assist_sumcheck_prove<E: ExtensionField>(
         // at λ=2: 2·row_at_1 - row_at_0
         let row_at_2: StateVec<E> = std::array::from_fn(|j| row_at_1[j].double() - row_at_0[j]);
 
-        let p0 = dot4(&row_at_0, &bwd_sum_d[0]);
-        let p1 = dot4(&row_at_1, &bwd_sum_d[1]);
-        let p2 = term_d1_d0_combine(
-            dot4(&row_at_2, &bwd_sum_d[0]),
-            dot4(&row_at_2, &bwd_sum_d[1]),
-        );
-
-        let _ = p0; // used only in debug assertions
+        let (mut p0, mut p1, mut p2) = (E::ZERO, E::ZERO, E::ZERO);
+        for (_, local_bwd_sum) in &partials {
+            let local_bwd_sum_d: [[E; ROBP_WIDTH]; 2] = [
+                std::array::from_fn(|s| na * local_bwd_sum[0][s] + alpha * local_bwd_sum[2][s]),
+                std::array::from_fn(|s| na * local_bwd_sum[1][s] + alpha * local_bwd_sum[3][s]),
+            ];
+            p0 += dot4(&row_at_0, &local_bwd_sum_d[0]);
+            p1 += dot4(&row_at_1, &local_bwd_sum_d[1]);
+            p2 += term_d1_d0_combine(
+                dot4(&row_at_2, &local_bwd_sum_d[0]),
+                dot4(&row_at_2, &local_bwd_sum_d[1]),
+            );
+        }
 
         transcript.append_field_element_ext(&p1);
         transcript.append_field_element_ext(&p2);

--- a/crates/mpcs/src/jagged/assist.rs
+++ b/crates/mpcs/src/jagged/assist.rs
@@ -1,0 +1,491 @@
+//! Jagged Assist Sumcheck
+//!
+//! Reduces K evaluations of the indicator function ĝ (one per column) to a
+//! single evaluation, via the batch-proving protocol of §5 (Lemma 5.1) of the
+//! jagged PCS paper.
+//!
+//! The sumcheck operates on P(b) = h(b) · Q(b) where:
+//!   h(z₃, z₄) = ĝ(z_row, ρ, z₃, z₄)   (multilinear in 2n variables)
+//!   Q(b) = Σ_y eq_col[y] · eq(b, x_y)   (x_y are Boolean evaluation points)
+//!
+//! Variables are interleaved as (z₃[0], z₄[0], z₃[1], z₄[1], …) so that
+//! each pair of consecutive sumcheck rounds maps to one ROBP step.
+
+use ff_ext::ExtensionField;
+use sumcheck::structs::{IOPProof, IOPProverMessage};
+use transcript::Transcript;
+
+use super::evaluator::{
+    ROBP_WIDTH, StateVec, TransitionMatrix, dot4, mat_vec_mul, sink_labels, source_vec,
+    symbol_transition_matrices, vec_mat_mul,
+};
+
+/// Run the assist sumcheck prover.
+///
+/// Proves that `claimed_sum = Σ_y eq_col[y] · ĝ(z_row, ρ, bits(t_y), bits(t_{y+1}))`.
+///
+/// Returns the proof (2·n_robp rounds) and the full challenge vector.
+pub fn assist_sumcheck_prove<E: ExtensionField>(
+    z_row_padded: &[E],
+    rho_padded: &[E],
+    eq_col: &[E],
+    cumulative_heights: &[usize],
+    n_robp: usize,
+    transcript: &mut impl Transcript<E>,
+) -> (IOPProof<E>, Vec<E>) {
+    let num_polys = cumulative_heights.len() - 1;
+    let n_vars = 2 * n_robp;
+    let max_degree: usize = 2;
+
+    // Write transcript header (must match verifier).
+    transcript.append_message(&n_vars.to_le_bytes());
+    transcript.append_message(&max_degree.to_le_bytes());
+
+    // Precompute per-step symbol matrices.
+    let step_mats: Vec<[TransitionMatrix<E>; 4]> = (0..n_robp)
+        .map(|i| symbol_transition_matrices(z_row_padded[i], rho_padded[i]))
+        .collect();
+
+    // Extract Boolean bits for each polynomial's evaluation points.
+    // x_y = interleaved (c_y[0], d_y[0], c_y[1], d_y[1], ...)
+    // c_y[i] = bit_i(t_y), d_y[i] = bit_i(t_{y+1})
+    let c_bits: Vec<Vec<usize>> = (0..num_polys)
+        .map(|y| {
+            (0..n_robp)
+                .map(|i| (cumulative_heights[y] >> i) & 1)
+                .collect()
+        })
+        .collect();
+    let d_bits: Vec<Vec<usize>> = (0..num_polys)
+        .map(|y| {
+            (0..n_robp)
+                .map(|i| (cumulative_heights[y + 1] >> i) & 1)
+                .collect()
+        })
+        .collect();
+
+    // Precompute backward vectors: bwd[y][i] for i ∈ [0, n_robp].
+    // bwd[y][n] = sink_labels, bwd[y][i] = M_i^{(c,d)} · bwd[y][i+1]
+    let u = sink_labels::<E>();
+    let mut bwd: Vec<Vec<StateVec<E>>> = Vec::with_capacity(num_polys);
+    for y in 0..num_polys {
+        let mut vecs = vec![[E::ZERO; ROBP_WIDTH]; n_robp + 1];
+        vecs[n_robp] = u;
+        for i in (0..n_robp).rev() {
+            let cd = c_bits[y][i] * 2 + d_bits[y][i];
+            vecs[i] = mat_vec_mul(&step_mats[i][cd], &vecs[i + 1]);
+        }
+        bwd.push(vecs);
+    }
+
+    // Initialize weights and forward vector.
+    let mut weights: Vec<E> = eq_col[..num_polys].to_vec();
+    let mut fwd: StateVec<E> = source_vec();
+
+    let mut challenges: Vec<E> = Vec::with_capacity(n_vars);
+    let mut proof_messages: Vec<IOPProverMessage<E>> = Vec::with_capacity(n_vars);
+
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..n_robp {
+        // Precompute fwd · M^{(c,d)} for all 4 symbols.
+        let r_cd: [StateVec<E>; 4] = std::array::from_fn(|cd| vec_mat_mul(&fwd, &step_mats[i][cd]));
+
+        // ---- Round 2i: bind z₃[i] ----
+        // Group backward vectors by (c, d) pair, weighted.
+        let mut bwd_sum = [[E::ZERO; ROBP_WIDTH]; 4];
+        for y in 0..num_polys {
+            let cd = c_bits[y][i] * 2 + d_bits[y][i];
+            let w = weights[y];
+            for s in 0..ROBP_WIDTH {
+                bwd_sum[cd][s] += w * bwd[y][i + 1][s];
+            }
+        }
+
+        // p(0): eq₁(0,c=0)=1, eq₁(0,c=1)=0. fwd_row(0,d) = R_{0,d}.
+        let p0 = dot4(&r_cd[0], &bwd_sum[0]) + dot4(&r_cd[1], &bwd_sum[1]);
+        // p(1): eq₁(1,c=0)=0, eq₁(1,c=1)=1. fwd_row(1,d) = R_{1,d}.
+        let p1 = dot4(&r_cd[2], &bwd_sum[2]) + dot4(&r_cd[3], &bwd_sum[3]);
+        // p(2): eq₁(2,c=0)=-1, eq₁(2,c=1)=2. fwd_row(2,d) = 2·R_{1,d} - R_{0,d}.
+        let row2_d0: StateVec<E> = std::array::from_fn(|j| r_cd[2][j].double() - r_cd[0][j]);
+        let row2_d1: StateVec<E> = std::array::from_fn(|j| r_cd[3][j].double() - r_cd[1][j]);
+        let term_c0 = dot4(&row2_d0, &bwd_sum[0]) + dot4(&row2_d1, &bwd_sum[1]);
+        let term_c1 = dot4(&row2_d0, &bwd_sum[2]) + dot4(&row2_d1, &bwd_sum[3]);
+        let p2 = term_c1.double() - term_c0;
+
+        debug_assert_eq!(
+            p0 + p1,
+            if i == 0 && challenges.is_empty() {
+                // First round: p(0)+p(1) should equal the claimed_sum.
+                // We don't have claimed_sum here but can skip the check.
+                p0 + p1
+            } else {
+                p0 + p1
+            }
+        );
+
+        transcript.append_field_element_ext(&p1);
+        transcript.append_field_element_ext(&p2);
+        let alpha = transcript
+            .sample_and_append_challenge(b"Internal round")
+            .elements;
+        challenges.push(alpha);
+        proof_messages.push(IOPProverMessage {
+            evaluations: vec![p1, p2],
+        });
+
+        // Update weights: w_y *= eq₁(α, c_y[i])
+        let na = E::ONE - alpha;
+        for y in 0..num_polys {
+            weights[y] *= if c_bits[y][i] == 0 { na } else { alpha };
+        }
+
+        // ---- Round 2i+1: bind z₄[i] ----
+        // Group by d only (c is already absorbed into weights).
+        let mut bwd_sum_d = [[E::ZERO; ROBP_WIDTH]; 2];
+        for y in 0..num_polys {
+            let d = d_bits[y][i];
+            let w = weights[y];
+            for s in 0..ROBP_WIDTH {
+                bwd_sum_d[d][s] += w * bwd[y][i + 1][s];
+            }
+        }
+
+        // fwd · T_full(α, λ) at λ=0: (1-α)·R_{0,0} + α·R_{1,0}
+        let row_at_0: StateVec<E> = std::array::from_fn(|j| na * r_cd[0][j] + alpha * r_cd[2][j]);
+        // at λ=1: (1-α)·R_{0,1} + α·R_{1,1}
+        let row_at_1: StateVec<E> = std::array::from_fn(|j| na * r_cd[1][j] + alpha * r_cd[3][j]);
+        // at λ=2: 2·row_at_1 - row_at_0
+        let row_at_2: StateVec<E> = std::array::from_fn(|j| row_at_1[j].double() - row_at_0[j]);
+
+        let p0 = dot4(&row_at_0, &bwd_sum_d[0]);
+        let p1 = dot4(&row_at_1, &bwd_sum_d[1]);
+        let p2 = term_d1_d0_combine(
+            dot4(&row_at_2, &bwd_sum_d[0]),
+            dot4(&row_at_2, &bwd_sum_d[1]),
+        );
+
+        let _ = p0; // used only in debug assertions
+
+        transcript.append_field_element_ext(&p1);
+        transcript.append_field_element_ext(&p2);
+        let beta = transcript
+            .sample_and_append_challenge(b"Internal round")
+            .elements;
+        challenges.push(beta);
+        proof_messages.push(IOPProverMessage {
+            evaluations: vec![p1, p2],
+        });
+
+        // Update weights: w_y *= eq₁(β, d_y[i])
+        let nb = E::ONE - beta;
+        for y in 0..num_polys {
+            weights[y] *= if d_bits[y][i] == 0 { nb } else { beta };
+        }
+
+        // Update forward vector: fwd ← fwd · T_full(α, β)
+        fwd = std::array::from_fn(|j| {
+            na * nb * r_cd[0][j]
+                + na * beta * r_cd[1][j]
+                + alpha * nb * r_cd[2][j]
+                + alpha * beta * r_cd[3][j]
+        });
+    }
+
+    (
+        IOPProof {
+            proofs: proof_messages,
+        },
+        challenges,
+    )
+}
+
+/// eq₁(2, d=0) = -1, eq₁(2, d=1) = 2.
+#[inline]
+fn term_d1_d0_combine<E: ExtensionField>(dot_d0: E, dot_d1: E) -> E {
+    dot_d1.double() - dot_d0
+}
+
+/// Compute Q(ρ*) = Σ_y eq_col[y] · eq(ρ*, x_y) where x_y are the interleaved
+/// Boolean evaluation points.
+///
+/// `assist_point` is the interleaved challenge point from the assist sumcheck,
+/// of length 2·n_robp.
+pub fn compute_q_at_assist_point<E: ExtensionField>(
+    assist_point: &[E],
+    eq_col: &[E],
+    cumulative_heights: &[usize],
+    n_robp: usize,
+) -> E {
+    let num_polys = cumulative_heights.len() - 1;
+    let mut q_val = E::ZERO;
+    for y in 0..num_polys {
+        let mut prod = eq_col[y];
+        if prod == E::ZERO {
+            continue;
+        }
+        for i in 0..n_robp {
+            let c_bit = (cumulative_heights[y] >> i) & 1;
+            let d_bit = (cumulative_heights[y + 1] >> i) & 1;
+            let z3_val = assist_point[2 * i];
+            let z4_val = assist_point[2 * i + 1];
+            prod *= if c_bit == 1 { z3_val } else { E::ONE - z3_val };
+            prod *= if d_bit == 1 { z4_val } else { E::ONE - z4_val };
+        }
+        q_val += prod;
+    }
+    q_val
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jagged::{
+        evaluator::{evaluate_g, evaluate_g_forward},
+        types::int_to_field_bits,
+    };
+    use ff_ext::{FromUniformBytes, GoldilocksExt2};
+    use multilinear_extensions::{util::ceil_log2, virtual_poly::build_eq_x_r_vec};
+    use p3::field::FieldAlgebra;
+    use rand::thread_rng;
+    use std::marker::PhantomData;
+    use sumcheck::structs::IOPVerifierState;
+    use transcript::basic::BasicTranscript;
+
+    type E = GoldilocksExt2;
+
+    /// Brute-force f̂(ρ) = Σ_y eq_col[y] · ĝ(z_row, ρ, bits(t_y), bits(t_{y+1}))
+    fn compute_f_at_point_slow(
+        z_row: &[E],
+        rho: &[E],
+        eq_col: &[E],
+        cumulative_heights: &[usize],
+        n_robp: usize,
+    ) -> E {
+        let num_polys = cumulative_heights.len() - 1;
+        let mut val = E::ZERO;
+        for y in 0..num_polys {
+            let t_lo = int_to_field_bits::<E>(cumulative_heights[y], n_robp);
+            let t_hi = int_to_field_bits::<E>(cumulative_heights[y + 1], n_robp);
+            val += eq_col[y] * evaluate_g(z_row, rho, &t_lo, &t_hi);
+        }
+        val
+    }
+
+    #[test]
+    fn test_assist_sumcheck_small() {
+        let mut rng = thread_rng();
+
+        // 4 polynomials with heights [4, 8, 4, 8] → cumulative [0, 4, 12, 16, 24]
+        let cumulative_heights = vec![0, 4, 12, 16, 24];
+        let num_polys = cumulative_heights.len() - 1;
+        let total_evals = *cumulative_heights.last().unwrap();
+        let num_giga_vars = ceil_log2(total_evals);
+        let n_robp = num_giga_vars + if total_evals.is_power_of_two() { 1 } else { 0 };
+
+        let z_row: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let rho: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let num_col_vars = ceil_log2(num_polys).max(1);
+        let z_col: Vec<E> = (0..num_col_vars).map(|_| E::random(&mut rng)).collect();
+        let eq_col = build_eq_x_r_vec(&z_col);
+
+        let claimed_sum =
+            compute_f_at_point_slow(&z_row, &rho, &eq_col, &cumulative_heights, n_robp);
+
+        // Run prover.
+        let mut transcript_p = BasicTranscript::<E>::new(b"assist_test");
+        let (proof, challenges) = assist_sumcheck_prove(
+            &z_row,
+            &rho,
+            &eq_col,
+            &cumulative_heights,
+            n_robp,
+            &mut transcript_p,
+        );
+
+        let n_vars = 2 * n_robp;
+        assert_eq!(proof.proofs.len(), n_vars);
+        assert_eq!(challenges.len(), n_vars);
+
+        // Verify using standard sumcheck verifier.
+        let mut transcript_v = BasicTranscript::<E>::new(b"assist_test");
+        let aux_info = multilinear_extensions::virtual_poly::VPAuxInfo {
+            max_degree: 2,
+            max_num_variables: n_vars,
+            phantom: PhantomData::<E>,
+        };
+        let subclaim =
+            IOPVerifierState::<E>::verify(claimed_sum, &proof, &aux_info, &mut transcript_v);
+
+        // Check challenges match.
+        for (sc, ch) in subclaim.point.iter().zip(challenges.iter()) {
+            assert_eq!(sc.elements, *ch);
+        }
+
+        // De-interleave the assist point: (z3[0], z4[0], z3[1], z4[1], ...)
+        let rho_star_c: Vec<E> = (0..n_robp).map(|i| challenges[2 * i]).collect();
+        let rho_star_d: Vec<E> = (0..n_robp).map(|i| challenges[2 * i + 1]).collect();
+
+        // h(ρ*) = ĝ(z_row, ρ, ρ*_c, ρ*_d)
+        let h_val = evaluate_g(&z_row, &rho, &rho_star_c, &rho_star_d);
+
+        // Q(ρ*) = Σ_y eq_col[y] · eq(ρ*, x_y)
+        let q_val = compute_q_at_assist_point(&challenges, &eq_col, &cumulative_heights, n_robp);
+
+        assert_eq!(
+            h_val * q_val,
+            subclaim.expected_evaluation,
+            "h(ρ*) * Q(ρ*) != subclaim"
+        );
+    }
+
+    #[test]
+    fn test_assist_sumcheck_single_poly() {
+        let mut rng = thread_rng();
+
+        let cumulative_heights = vec![0, 8];
+        let total_evals = 8;
+        let num_giga_vars = ceil_log2(total_evals);
+        let n_robp = num_giga_vars + if total_evals.is_power_of_two() { 1 } else { 0 };
+
+        let z_row: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let rho: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let eq_col = vec![E::ONE]; // single poly
+
+        let claimed_sum =
+            compute_f_at_point_slow(&z_row, &rho, &eq_col, &cumulative_heights, n_robp);
+
+        let mut transcript_p = BasicTranscript::<E>::new(b"assist_single");
+        let (proof, challenges) = assist_sumcheck_prove(
+            &z_row,
+            &rho,
+            &eq_col,
+            &cumulative_heights,
+            n_robp,
+            &mut transcript_p,
+        );
+
+        let n_vars = 2 * n_robp;
+        let mut transcript_v = BasicTranscript::<E>::new(b"assist_single");
+        let aux_info = multilinear_extensions::virtual_poly::VPAuxInfo {
+            max_degree: 2,
+            max_num_variables: n_vars,
+            phantom: PhantomData::<E>,
+        };
+        let subclaim =
+            IOPVerifierState::<E>::verify(claimed_sum, &proof, &aux_info, &mut transcript_v);
+
+        let rho_star_c: Vec<E> = (0..n_robp).map(|i| challenges[2 * i]).collect();
+        let rho_star_d: Vec<E> = (0..n_robp).map(|i| challenges[2 * i + 1]).collect();
+        let h_val = evaluate_g(&z_row, &rho, &rho_star_c, &rho_star_d);
+        let q_val = compute_q_at_assist_point(&challenges, &eq_col, &cumulative_heights, n_robp);
+
+        assert_eq!(h_val * q_val, subclaim.expected_evaluation);
+    }
+
+    #[test]
+    fn test_assist_sumcheck_many_polys() {
+        let mut rng = thread_rng();
+
+        // 16 polynomials, each height 32 → cumulative [0, 32, 64, ..., 512]
+        let num_polys = 16;
+        let poly_height = 32usize;
+        let cumulative_heights: Vec<usize> = (0..=num_polys).map(|i| i * poly_height).collect();
+        let total_evals = *cumulative_heights.last().unwrap();
+        let num_giga_vars = ceil_log2(total_evals);
+        let n_robp = num_giga_vars + if total_evals.is_power_of_two() { 1 } else { 0 };
+
+        let z_row: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let rho: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let num_col_vars = ceil_log2(num_polys).max(1);
+        let z_col: Vec<E> = (0..num_col_vars).map(|_| E::random(&mut rng)).collect();
+        let eq_col = build_eq_x_r_vec(&z_col);
+
+        let claimed_sum =
+            compute_f_at_point_slow(&z_row, &rho, &eq_col, &cumulative_heights, n_robp);
+
+        let mut transcript_p = BasicTranscript::<E>::new(b"assist_many");
+        let (proof, challenges) = assist_sumcheck_prove(
+            &z_row,
+            &rho,
+            &eq_col,
+            &cumulative_heights,
+            n_robp,
+            &mut transcript_p,
+        );
+
+        let n_vars = 2 * n_robp;
+        let mut transcript_v = BasicTranscript::<E>::new(b"assist_many");
+        let aux_info = multilinear_extensions::virtual_poly::VPAuxInfo {
+            max_degree: 2,
+            max_num_variables: n_vars,
+            phantom: PhantomData::<E>,
+        };
+        let subclaim =
+            IOPVerifierState::<E>::verify(claimed_sum, &proof, &aux_info, &mut transcript_v);
+
+        for (sc, ch) in subclaim.point.iter().zip(challenges.iter()) {
+            assert_eq!(sc.elements, *ch);
+        }
+
+        let rho_star_c: Vec<E> = (0..n_robp).map(|i| challenges[2 * i]).collect();
+        let rho_star_d: Vec<E> = (0..n_robp).map(|i| challenges[2 * i + 1]).collect();
+        let h_val = evaluate_g(&z_row, &rho, &rho_star_c, &rho_star_d);
+        let q_val = compute_q_at_assist_point(&challenges, &eq_col, &cumulative_heights, n_robp);
+
+        assert_eq!(h_val * q_val, subclaim.expected_evaluation);
+    }
+
+    /// Also verify using the forward evaluator for cross-validation.
+    #[test]
+    fn test_assist_forward_backward_consistency() {
+        let mut rng = thread_rng();
+
+        let cumulative_heights = vec![0, 3, 7, 10];
+        let num_polys = 3;
+        let total_evals = 10;
+        let num_giga_vars = ceil_log2(total_evals);
+        let n_robp = num_giga_vars + if total_evals.is_power_of_two() { 1 } else { 0 };
+
+        let z_row: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let rho: Vec<E> = (0..n_robp).map(|_| E::random(&mut rng)).collect();
+        let eq_col = build_eq_x_r_vec(&vec![E::random(&mut rng); ceil_log2(num_polys).max(1)]);
+
+        // Compute f̂(ρ) using both forward and backward evaluators.
+        let mut f_fwd = E::ZERO;
+        let mut f_bwd = E::ZERO;
+        for y in 0..num_polys {
+            let t_lo = int_to_field_bits::<E>(cumulative_heights[y], n_robp);
+            let t_hi = int_to_field_bits::<E>(cumulative_heights[y + 1], n_robp);
+            f_fwd += eq_col[y] * evaluate_g_forward(&z_row, &rho, &t_lo, &t_hi);
+            f_bwd += eq_col[y] * evaluate_g(&z_row, &rho, &t_lo, &t_hi);
+        }
+        assert_eq!(f_fwd, f_bwd, "forward/backward f̂ disagree");
+
+        // Run assist sumcheck and verify.
+        let mut transcript_p = BasicTranscript::<E>::new(b"assist_fb");
+        let (proof, challenges) = assist_sumcheck_prove(
+            &z_row,
+            &rho,
+            &eq_col,
+            &cumulative_heights,
+            n_robp,
+            &mut transcript_p,
+        );
+
+        let n_vars = 2 * n_robp;
+        let mut transcript_v = BasicTranscript::<E>::new(b"assist_fb");
+        let aux_info = multilinear_extensions::virtual_poly::VPAuxInfo {
+            max_degree: 2,
+            max_num_variables: n_vars,
+            phantom: PhantomData::<E>,
+        };
+        let subclaim = IOPVerifierState::<E>::verify(f_bwd, &proof, &aux_info, &mut transcript_v);
+
+        let rho_star_c: Vec<E> = (0..n_robp).map(|i| challenges[2 * i]).collect();
+        let rho_star_d: Vec<E> = (0..n_robp).map(|i| challenges[2 * i + 1]).collect();
+        let h_val = evaluate_g(&z_row, &rho, &rho_star_c, &rho_star_d);
+        let q_val = compute_q_at_assist_point(&challenges, &eq_col, &cumulative_heights, n_robp);
+
+        assert_eq!(h_val * q_val, subclaim.expected_evaluation);
+    }
+}

--- a/crates/mpcs/src/jagged/evaluator.rs
+++ b/crates/mpcs/src/jagged/evaluator.rs
@@ -14,6 +14,111 @@ use ff_ext::ExtensionField;
 // the sink label vector.
 // ---------------------------------------------------------------------------
 
+pub const ROBP_WIDTH: usize = 4;
+
+pub type StateVec<E> = [E; ROBP_WIDTH];
+pub type TransitionMatrix<E> = [[E; ROBP_WIDTH]; ROBP_WIDTH];
+
+/// Sink label vector: accept at state (carry=0, lt=1) = index 1.
+pub fn sink_labels<E: ExtensionField>() -> StateVec<E> {
+    let mut u = [E::ZERO; ROBP_WIDTH];
+    u[1] = E::ONE;
+    u
+}
+
+/// Initial forward vector: source state (carry=0, lt=0) = index 0.
+pub fn source_vec<E: ExtensionField>() -> StateVec<E> {
+    let mut v = [E::ZERO; ROBP_WIDTH];
+    v[0] = E::ONE;
+    v
+}
+
+#[inline]
+pub fn dot4<E: ExtensionField>(a: &StateVec<E>, b: &StateVec<E>) -> E {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3]
+}
+
+/// Row-vector × matrix: out[j] = Σ_i v[i] * m[i][j].
+#[inline]
+pub fn vec_mat_mul<E: ExtensionField>(v: &StateVec<E>, m: &TransitionMatrix<E>) -> StateVec<E> {
+    std::array::from_fn(|j| v[0] * m[0][j] + v[1] * m[1][j] + v[2] * m[2][j] + v[3] * m[3][j])
+}
+
+/// Matrix × column-vector: out[i] = Σ_j m[i][j] * v[j].
+#[inline]
+pub fn mat_vec_mul<E: ExtensionField>(m: &TransitionMatrix<E>, v: &StateVec<E>) -> StateVec<E> {
+    std::array::from_fn(|i| m[i][0] * v[0] + m[i][1] * v[1] + m[i][2] * v[2] + m[i][3] * v[3])
+}
+
+/// Per-symbol transition matrices M_i^{(c,d)} at one ROBP step, with
+/// z1 (= z_row[i]) and z2 (= ρ[i]) eq-weights baked in.
+///
+/// Returns 4 matrices indexed by `c * 2 + d` for `(c, d) ∈ {0,1}²`.
+/// Matrix entry `m[from][to]` gives the transition weight from `from` to `to`
+/// when reading symbol `(c, d)`.
+///
+/// The full eq-weighted transition matrix is recovered as:
+///   T_i = Σ_{c,d} eq₁(z3, c) · eq₁(z4, d) · M_i^{(c,d)}
+pub fn symbol_transition_matrices<E: ExtensionField>(z1i: E, z2i: E) -> [TransitionMatrix<E>; 4] {
+    let (nz1, nz2) = (E::ONE - z1i, E::ONE - z2i);
+    let ab00 = nz1 * nz2; // eq₁(z1, 0) · eq₁(z2, 0)
+    let ab01 = nz1 * z2i; // eq₁(z1, 0) · eq₁(z2, 1)
+    let ab10 = z1i * nz2; // eq₁(z1, 1) · eq₁(z2, 0)
+    let ab11 = z1i * z2i; // eq₁(z1, 1) · eq₁(z2, 1)
+
+    let z = E::ZERO;
+
+    // M^{(0,0)}: symbol (a, b, c=0, d=0)
+    // carry_in=0, a=0: sum=0, b=0, co=0, ab00, b=d→preserve
+    // carry_in=0, a=1: sum=1, b=1, co=0, ab11, b>d→lt=0
+    // carry_in=1, a=0: sum=1, b=1, co=0, ab01, b>d→lt=0
+    // carry_in=1, a=1: sum=2, b=0, co=1, ab10, b=d→preserve
+    let m00: TransitionMatrix<E> = [
+        [ab00 + ab11, z, z, z],
+        [ab11, ab00, z, z],
+        [ab01, z, ab10, z],
+        [ab01, z, z, ab10],
+    ];
+
+    // M^{(0,1)}: symbol (a, b, c=0, d=1)
+    // carry_in=0, a=0: sum=0, b=0, co=0, ab00, b<d→lt=1
+    // carry_in=0, a=1: sum=1, b=1, co=0, ab11, b=d→preserve
+    // carry_in=1, a=0: sum=1, b=1, co=0, ab01, b=d→preserve
+    // carry_in=1, a=1: sum=2, b=0, co=1, ab10, b<d→lt=1
+    let m01: TransitionMatrix<E> = [
+        [ab11, ab00, z, z],
+        [z, ab00 + ab11, z, z],
+        [ab01, z, z, ab10],
+        [z, ab01, z, ab10],
+    ];
+
+    // M^{(1,0)}: symbol (a, b, c=1, d=0)
+    // carry_in=0, a=0: sum=1, b=1, co=0, ab01, b>d→lt=0
+    // carry_in=0, a=1: sum=2, b=0, co=1, ab10, b=d→preserve
+    // carry_in=1, a=0: sum=2, b=0, co=1, ab00, b=d→preserve
+    // carry_in=1, a=1: sum=3, b=1, co=1, ab11, b>d→lt=0
+    let m10: TransitionMatrix<E> = [
+        [ab01, z, ab10, z],
+        [ab01, z, z, ab10],
+        [z, z, ab00 + ab11, z],
+        [z, z, ab11, ab00],
+    ];
+
+    // M^{(1,1)}: symbol (a, b, c=1, d=1)
+    // carry_in=0, a=0: sum=1, b=1, co=0, ab01, b=d→preserve
+    // carry_in=0, a=1: sum=2, b=0, co=1, ab10, b<d→lt=1
+    // carry_in=1, a=0: sum=2, b=0, co=1, ab00, b<d→lt=1
+    // carry_in=1, a=1: sum=3, b=1, co=1, ab11, b=d→preserve
+    let m11: TransitionMatrix<E> = [
+        [ab01, z, z, ab10],
+        [z, ab01, z, ab10],
+        [z, z, ab11, ab00],
+        [z, z, z, ab00 + ab11],
+    ];
+
+    [m00, m01, m10, m11]
+}
+
 /// Compute the eq-weighted transition matrix at step `i`.
 ///
 /// Returns `(T_same, T_lt1, T_lt0)`: three 2×2 matrices (indexed by carry)
@@ -191,7 +296,7 @@ mod tests {
     use p3::field::FieldAlgebra;
     use rand::thread_rng;
 
-    use super::{evaluate_g_backward, evaluate_g_forward};
+    use super::*;
 
     type E = BabyBearExt4;
 
@@ -261,6 +366,94 @@ mod tests {
             let fwd = evaluate_g_forward(&z1, &z2, &z3, &z4);
             let bwd = evaluate_g_backward(&z1, &z2, &z3, &z4);
             assert_eq!(fwd, bwd, "forward != backward at n={n}");
+        }
+    }
+
+    /// Verify that recombining per-symbol matrices reproduces transition_weights.
+    #[test]
+    fn test_symbol_matrices_match_transition_weights() {
+        let mut rng = thread_rng();
+        for _ in 0..20 {
+            let z1i = E::random(&mut rng);
+            let z2i = E::random(&mut rng);
+            let z3i = E::random(&mut rng);
+            let z4i = E::random(&mut rng);
+
+            let mats = symbol_transition_matrices(z1i, z2i);
+            let (nz3, nz4) = (E::ONE - z3i, E::ONE - z4i);
+            let cd_weights = [nz3 * nz4, nz3 * z4i, z3i * nz4, z3i * z4i];
+
+            // Reconstruct T = Σ_{c,d} eq₁(z3,c)·eq₁(z4,d)·M^{(c,d)}
+            let mut t_recon = [[E::ZERO; 4]; 4];
+            for cd in 0..4 {
+                for i in 0..4 {
+                    for j in 0..4 {
+                        t_recon[i][j] += cd_weights[cd] * mats[cd][i][j];
+                    }
+                }
+            }
+
+            // Compare against transition_weights-based backward step.
+            let transitions = transition_weights(z1i, z2i, z3i, z4i);
+            let mut t_expected = [[E::ZERO; 4]; 4];
+            for &(ci, co, w_same, w_lt1, w_lt0) in &transitions {
+                // M[from][to] convention, matching backward pass.
+                t_expected[ci * 2][co * 2] += w_same + w_lt0;
+                t_expected[ci * 2][co * 2 + 1] += w_lt1;
+                t_expected[ci * 2 + 1][co * 2] += w_lt0;
+                t_expected[ci * 2 + 1][co * 2 + 1] += w_same + w_lt1;
+            }
+
+            assert_eq!(
+                t_recon, t_expected,
+                "symbol matrices don't match transition_weights"
+            );
+        }
+    }
+
+    /// Verify backward precomputation: using per-symbol matrices with Boolean
+    /// (c, d) reproduces evaluate_g.
+    #[test]
+    fn test_backward_via_symbol_matrices() {
+        let mut rng = thread_rng();
+        for n in 1..=5 {
+            let z1: Vec<E> = (0..n).map(|_| E::random(&mut rng)).collect();
+            let z2: Vec<E> = (0..n).map(|_| E::random(&mut rng)).collect();
+            let z3: Vec<E> = (0..n).map(|_| E::random(&mut rng)).collect();
+            let z4: Vec<E> = (0..n).map(|_| E::random(&mut rng)).collect();
+
+            let expected = evaluate_g_backward(&z1, &z2, &z3, &z4);
+
+            // Compute using per-symbol matrices with Boolean (c, d) from z3/z4.
+            // Round each z3[i]/z4[i] to the nearest bit for this test — instead,
+            // use evaluate_g with actual field elements and compare using the
+            // matrix product approach.
+            let step_mats: Vec<_> = (0..n)
+                .map(|i| symbol_transition_matrices(z1[i], z2[i]))
+                .collect();
+
+            // Build T_i = Σ_{c,d} eq1(z3[i],c)*eq1(z4[i],d)*M^{(c,d)}
+            // and multiply backward.
+            let u = sink_labels::<E>();
+            let mut val = u;
+            for i in (0..n).rev() {
+                let (nz3, nz4) = (E::ONE - z3[i], E::ONE - z4[i]);
+                let cd_w = [nz3 * nz4, nz3 * z4[i], z3[i] * nz4, z3[i] * z4[i]];
+                let mut t_i = [[E::ZERO; 4]; 4];
+                for cd in 0..4 {
+                    for r in 0..4 {
+                        for c in 0..4 {
+                            t_i[r][c] += cd_w[cd] * step_mats[i][cd][r][c];
+                        }
+                    }
+                }
+                val = mat_vec_mul(&t_i, &val);
+            }
+            let result = val[0]; // source state
+            assert_eq!(
+                result, expected,
+                "symbol-matrix backward != evaluate_g at n={n}"
+            );
         }
     }
 }

--- a/crates/mpcs/src/jagged/evaluator.rs
+++ b/crates/mpcs/src/jagged/evaluator.rs
@@ -12,6 +12,12 @@ use ff_ext::ExtensionField;
 // where Tᵢ = Σ_{σ ∈ {0,1}⁴} eq(ζᵢ, σ) · M^(σ) is the eq-weighted
 // transition matrix at step i, e₁ is the initial state vector, and u is
 // the sink label vector.
+//
+// Since multilinear variables can be bound in any order, we fix z₁ and z₂
+// first (to z_row and ρ), which reduces the per-step alphabet from {0,1}⁴
+// to {0,1}² and gives the 4 matrices M_i^{(c,d)}.  The remaining variables
+// z₃, z₄ are then interleaved as (z₃[0], z₄[0], z₃[1], …) to match the
+// ROBP step order, enabling the forward/backward decomposition.
 // ---------------------------------------------------------------------------
 
 pub const ROBP_WIDTH: usize = 4;
@@ -50,6 +56,41 @@ pub fn mat_vec_mul<E: ExtensionField>(m: &TransitionMatrix<E>, v: &StateVec<E>) 
     std::array::from_fn(|i| m[i][0] * v[0] + m[i][1] * v[1] + m[i][2] * v[2] + m[i][3] * v[3])
 }
 
+/// Raw ROBP transition table for the indicator g(a,b,c,d) = [a+c=b ∧ b<d].
+///
+/// `ROBP_TRANSITION[from_state][symbol]` = `to_state`, where:
+///   - state = carry * 2 + lt
+///   - symbol = a * 8 + b * 4 + c * 2 + d
+///
+/// A value of `REJECT` (0xFF) means the transition leads to a rejecting sink
+/// (inconsistent addition: LSB of a + c + carry_in ≠ b).
+const REJECT: u8 = 0xFF;
+
+static ROBP_TRANSITION: [[u8; 16]; ROBP_WIDTH] = {
+    let mut table = [[REJECT; 16]; ROBP_WIDTH];
+    let mut from = 0u8;
+    while from < 4 {
+        let carry_in = from >> 1;
+        let lt_in = from & 1;
+        let mut sym = 0u8;
+        while sym < 16 {
+            let a = sym >> 3;
+            let b = (sym >> 2) & 1;
+            let c = (sym >> 1) & 1;
+            let d = sym & 1;
+            let sum = a + c + carry_in;
+            if sum & 1 == b {
+                let carry_out = sum >> 1;
+                let lt_out = if b < d { 1 } else if b == d { lt_in } else { 0 };
+                table[from as usize][sym as usize] = carry_out * 2 + lt_out;
+            }
+            sym += 1;
+        }
+        from += 1;
+    }
+    table
+};
+
 /// Per-symbol transition matrices M_i^{(c,d)} at one ROBP step, with
 /// z1 (= z_row[i]) and z2 (= ρ[i]) eq-weights baked in.
 ///
@@ -57,66 +98,30 @@ pub fn mat_vec_mul<E: ExtensionField>(m: &TransitionMatrix<E>, v: &StateVec<E>) 
 /// Matrix entry `m[from][to]` gives the transition weight from `from` to `to`
 /// when reading symbol `(c, d)`.
 ///
+/// Derived from the raw ROBP transition table via:
+///   M_i^{(c,d)}[from][to] = Σ_{a,b} eq₁(z1,a) · eq₁(z2,b) · [transition(from,(a,b,c,d)) = to]
+///
 /// The full eq-weighted transition matrix is recovered as:
 ///   T_i = Σ_{c,d} eq₁(z3, c) · eq₁(z4, d) · M_i^{(c,d)}
 pub fn symbol_transition_matrices<E: ExtensionField>(z1i: E, z2i: E) -> [TransitionMatrix<E>; 4] {
-    let (nz1, nz2) = (E::ONE - z1i, E::ONE - z2i);
-    let ab00 = nz1 * nz2; // eq₁(z1, 0) · eq₁(z2, 0)
-    let ab01 = nz1 * z2i; // eq₁(z1, 0) · eq₁(z2, 1)
-    let ab10 = z1i * nz2; // eq₁(z1, 1) · eq₁(z2, 0)
-    let ab11 = z1i * z2i; // eq₁(z1, 1) · eq₁(z2, 1)
+    let eq_ab: [E; 4] = {
+        let (nz1, nz2) = (E::ONE - z1i, E::ONE - z2i);
+        [nz1 * nz2, nz1 * z2i, z1i * nz2, z1i * z2i]
+    };
 
-    let z = E::ZERO;
-
-    // M^{(0,0)}: symbol (a, b, c=0, d=0)
-    // carry_in=0, a=0: sum=0, b=0, co=0, ab00, b=d→preserve
-    // carry_in=0, a=1: sum=1, b=1, co=0, ab11, b>d→lt=0
-    // carry_in=1, a=0: sum=1, b=1, co=0, ab01, b>d→lt=0
-    // carry_in=1, a=1: sum=2, b=0, co=1, ab10, b=d→preserve
-    let m00: TransitionMatrix<E> = [
-        [ab00 + ab11, z, z, z],
-        [ab11, ab00, z, z],
-        [ab01, z, ab10, z],
-        [ab01, z, z, ab10],
-    ];
-
-    // M^{(0,1)}: symbol (a, b, c=0, d=1)
-    // carry_in=0, a=0: sum=0, b=0, co=0, ab00, b<d→lt=1
-    // carry_in=0, a=1: sum=1, b=1, co=0, ab11, b=d→preserve
-    // carry_in=1, a=0: sum=1, b=1, co=0, ab01, b=d→preserve
-    // carry_in=1, a=1: sum=2, b=0, co=1, ab10, b<d→lt=1
-    let m01: TransitionMatrix<E> = [
-        [ab11, ab00, z, z],
-        [z, ab00 + ab11, z, z],
-        [ab01, z, z, ab10],
-        [z, ab01, z, ab10],
-    ];
-
-    // M^{(1,0)}: symbol (a, b, c=1, d=0)
-    // carry_in=0, a=0: sum=1, b=1, co=0, ab01, b>d→lt=0
-    // carry_in=0, a=1: sum=2, b=0, co=1, ab10, b=d→preserve
-    // carry_in=1, a=0: sum=2, b=0, co=1, ab00, b=d→preserve
-    // carry_in=1, a=1: sum=3, b=1, co=1, ab11, b>d→lt=0
-    let m10: TransitionMatrix<E> = [
-        [ab01, z, ab10, z],
-        [ab01, z, z, ab10],
-        [z, z, ab00 + ab11, z],
-        [z, z, ab11, ab00],
-    ];
-
-    // M^{(1,1)}: symbol (a, b, c=1, d=1)
-    // carry_in=0, a=0: sum=1, b=1, co=0, ab01, b=d→preserve
-    // carry_in=0, a=1: sum=2, b=0, co=1, ab10, b<d→lt=1
-    // carry_in=1, a=0: sum=2, b=0, co=1, ab00, b<d→lt=1
-    // carry_in=1, a=1: sum=3, b=1, co=1, ab11, b=d→preserve
-    let m11: TransitionMatrix<E> = [
-        [ab01, z, z, ab10],
-        [z, ab01, z, ab10],
-        [z, z, ab11, ab00],
-        [z, z, z, ab00 + ab11],
-    ];
-
-    [m00, m01, m10, m11]
+    let mut mats = [[[E::ZERO; ROBP_WIDTH]; ROBP_WIDTH]; 4];
+    for cd in 0..4u8 {
+        for from in 0..ROBP_WIDTH {
+            for ab in 0..4u8 {
+                let sym = (ab << 2) | cd;
+                let to = ROBP_TRANSITION[from][sym as usize];
+                if to != REJECT {
+                    mats[cd as usize][from][to as usize] += eq_ab[ab as usize];
+                }
+            }
+        }
+    }
+    mats
 }
 
 /// Compute the eq-weighted transition matrix at step `i`.

--- a/crates/mpcs/src/jagged/evaluator.rs
+++ b/crates/mpcs/src/jagged/evaluator.rs
@@ -81,7 +81,13 @@ static ROBP_TRANSITION: [[u8; 16]; ROBP_WIDTH] = {
             let sum = a + c + carry_in;
             if sum & 1 == b {
                 let carry_out = sum >> 1;
-                let lt_out = if b < d { 1 } else if b == d { lt_in } else { 0 };
+                let lt_out = if b < d {
+                    1
+                } else if b == d {
+                    lt_in
+                } else {
+                    0
+                };
                 table[from as usize][sym as usize] = carry_out * 2 + lt_out;
             }
             sym += 1;
@@ -111,6 +117,7 @@ pub fn symbol_transition_matrices<E: ExtensionField>(z1i: E, z2i: E) -> [Transit
 
     let mut mats = [[[E::ZERO; ROBP_WIDTH]; ROBP_WIDTH]; 4];
     for cd in 0..4u8 {
+        #[allow(clippy::needless_range_loop)]
         for from in 0..ROBP_WIDTH {
             for ab in 0..4u8 {
                 let sym = (ab << 2) | cd;

--- a/crates/mpcs/src/jagged/evaluator.rs
+++ b/crates/mpcs/src/jagged/evaluator.rs
@@ -398,6 +398,7 @@ mod tests {
             // Reconstruct T = Σ_{c,d} eq₁(z3,c)·eq₁(z4,d)·M^{(c,d)}
             let mut t_recon = [[E::ZERO; 4]; 4];
             for cd in 0..4 {
+                #[allow(clippy::needless_range_loop)]
                 for i in 0..4 {
                     for j in 0..4 {
                         t_recon[i][j] += cd_weights[cd] * mats[cd][i][j];
@@ -452,6 +453,7 @@ mod tests {
                 let (nz3, nz4) = (E::ONE - z3[i], E::ONE - z4[i]);
                 let cd_w = [nz3 * nz4, nz3 * z4[i], z3[i] * nz4, z3[i] * z4[i]];
                 let mut t_i = [[E::ZERO; 4]; 4];
+                #[allow(clippy::needless_range_loop)]
                 for cd in 0..4 {
                     for r in 0..4 {
                         for c in 0..4 {

--- a/crates/mpcs/src/jagged/mod.rs
+++ b/crates/mpcs/src/jagged/mod.rs
@@ -160,12 +160,10 @@ use multilinear_extensions::{
     util::ceil_log2,
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec},
 };
-use p3::{
-    matrix::{Matrix, bitrev::BitReversableMatrix},
-    maybe_rayon::prelude::{
-        IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSliceMut,
-    },
-};
+use p3::matrix::{Matrix, bitrev::BitReversableMatrix};
+#[cfg(feature = "parallel")]
+use p3::maybe_rayon::prelude::IndexedParallelIterator;
+use p3::maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator, ParallelSliceMut};
 use transcript::Transcript;
 use types::int_to_field_bits;
 use witness::{InstancePaddingStrategy, RowMajorMatrix};

--- a/crates/mpcs/src/jagged/mod.rs
+++ b/crates/mpcs/src/jagged/mod.rs
@@ -139,10 +139,12 @@
 //! `h(ρ)`. The ROBP makes `ĝ` efficiently evaluable, so the verifier computes
 //! `h(ρ) = Σ_i eq(z_c, i) · ĝ(z_r, ρ, t[i], t[i+1])` in `O(K·n)` time.
 
+pub mod assist;
 pub mod evaluator;
 pub mod sumcheck;
 mod types;
 
+pub use assist::{assist_sumcheck_prove, compute_q_at_assist_point};
 pub use evaluator::{evaluate_g, evaluate_g_backward, evaluate_g_forward};
 pub use sumcheck::{JaggedSumcheckInput, jagged_sumcheck_prove};
 pub use types::{JaggedBatchOpenProof, JaggedCommitment, JaggedCommitmentWithWitness};
@@ -396,26 +398,54 @@ pub fn jagged_batch_open<E: ExtensionField, InnerPcs: PolynomialCommitmentScheme
         num_giga_vars,
         cumulative_heights: &comm.cumulative_heights,
         eq_row,
-        eq_col,
+        eq_col: eq_col.to_vec(),
     };
     let (sumcheck_proof, challenges) = jagged_sumcheck_prove(&input, transcript, None);
+    let rho = challenges;
 
     // Evaluate q'(ρ).
-    let q_eval = q_mle.evaluate(&challenges);
+    let q_eval = q_mle.evaluate(&rho);
 
-    // Write q_eval to transcript before inner PCS open.
+    // Compute f̂(ρ) = Σ_y eq_col[y] · ĝ(z_row, ρ, bits(t_y), bits(t_{y+1})).
+    let n_robp = num_giga_vars + if total_evals.is_power_of_two() { 1 } else { 0 };
+    let mut z_row_padded = z_row;
+    z_row_padded.resize(n_robp, E::ZERO);
+    let mut rho_padded = rho.clone();
+    rho_padded.resize(n_robp, E::ZERO);
+    let f_at_rho = compute_f_at_point(
+        &z_row_padded,
+        &rho_padded,
+        &eq_col,
+        &comm.cumulative_heights,
+        n_robp,
+    );
+
+    // Write q_eval and f_at_rho to transcript.
     transcript.append_field_element_ext(&q_eval);
+    transcript.append_field_element_ext(&f_at_rho);
+
+    // Run the assist sumcheck to prove f̂(ρ) is correct.
+    let (assist_proof, _assist_challenges) = assist_sumcheck_prove(
+        &z_row_padded,
+        &rho_padded,
+        &eq_col,
+        &comm.cumulative_heights,
+        n_robp,
+        transcript,
+    );
 
     // Open q' at ρ via inner PCS batch_open.
     let inner_proof = InnerPcs::batch_open(
         pp,
-        vec![(&comm.inner, vec![(challenges, vec![q_eval])])],
+        vec![(&comm.inner, vec![(rho, vec![q_eval])])],
         transcript,
     )?;
 
     Ok(JaggedBatchOpenProof {
         sumcheck_proof,
         q_eval,
+        f_at_rho,
+        assist_proof,
         inner_proof,
     })
 }
@@ -484,26 +514,47 @@ pub fn jagged_batch_verify<E: ExtensionField, InnerPcs: PolynomialCommitmentSche
     // When total_evals is an exact power of 2, num_giga_vars bits can't represent it.
     let n_robp = num_giga_vars + if total_evals.is_power_of_two() { 1 } else { 0 };
 
-    // Compute f̂(ρ) via the ROBP evaluator.
+    // Write q_eval and f_at_rho to transcript (must match prover).
+    transcript.append_field_element_ext(&proof.q_eval);
+    transcript.append_field_element_ext(&proof.f_at_rho);
+
+    // Check multiplicative subclaim: q'(ρ) · f̂(ρ) == expected_evaluation.
+    if proof.q_eval * proof.f_at_rho != subclaim.expected_evaluation {
+        return Err(Error::InvalidPcsOpen(
+            "jagged_batch_verify: q_eval * f(rho) != subclaim expected evaluation".into(),
+        ));
+    }
+
+    // Verify the assist sumcheck: proves that f_at_rho is correct.
+    let n_assist = 2 * n_robp;
+    let assist_aux = VPAuxInfo {
+        max_degree: 2,
+        max_num_variables: n_assist,
+        phantom: PhantomData::<E>,
+    };
+    let assist_subclaim =
+        IOPVerifierState::<E>::verify(proof.f_at_rho, &proof.assist_proof, &assist_aux, transcript);
+    let assist_point: Vec<E> = assist_subclaim.point.iter().map(|c| c.elements).collect();
+
+    // De-interleave the assist point: (z3[0], z4[0], z3[1], z4[1], ...)
+    let rho_star_c: Vec<E> = (0..n_robp).map(|i| assist_point[2 * i]).collect();
+    let rho_star_d: Vec<E> = (0..n_robp).map(|i| assist_point[2 * i + 1]).collect();
+
+    // h(ρ*) = ĝ(z_row_padded, ρ_padded, ρ*_c, ρ*_d) — one ROBP evaluation.
     let mut z_row_padded = z_row;
     z_row_padded.resize(n_robp, E::ZERO);
     let mut rho_padded = rho.clone();
     rho_padded.resize(n_robp, E::ZERO);
-    let f_at_rho = compute_f_at_point(
-        &z_row_padded,
-        &rho_padded,
-        &eq_col,
-        &comm.cumulative_heights,
-        n_robp,
-    );
+    let h_at_rho_star = evaluate_g(&z_row_padded, &rho_padded, &rho_star_c, &rho_star_d);
 
-    // Write q_eval to transcript (must match prover).
-    transcript.append_field_element_ext(&proof.q_eval);
+    // Q(ρ*) = Σ_y eq_col[y] · eq(ρ*, x_y).
+    let q_at_rho_star =
+        compute_q_at_assist_point(&assist_point, &eq_col, &comm.cumulative_heights, n_robp);
 
-    // Check subclaim: q'(ρ) · f̂(ρ) == expected_evaluation.
-    if proof.q_eval * f_at_rho != subclaim.expected_evaluation {
+    // Check assist subclaim: h(ρ*) · Q(ρ*) == expected_evaluation.
+    if h_at_rho_star * q_at_rho_star != assist_subclaim.expected_evaluation {
         return Err(Error::InvalidPcsOpen(
-            "jagged_batch_verify: q_eval * f(rho) != subclaim expected evaluation".into(),
+            "jagged_batch_verify: assist sumcheck final check failed".into(),
         ));
     }
 

--- a/crates/mpcs/src/jagged/mod.rs
+++ b/crates/mpcs/src/jagged/mod.rs
@@ -160,10 +160,12 @@ use multilinear_extensions::{
     util::ceil_log2,
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec},
 };
-use p3::matrix::{Matrix, bitrev::BitReversableMatrix};
 #[cfg(feature = "parallel")]
 use p3::maybe_rayon::prelude::IndexedParallelIterator;
-use p3::maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator, ParallelSliceMut};
+use p3::{
+    matrix::{Matrix, bitrev::BitReversableMatrix},
+    maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator, ParallelSliceMut},
+};
 use transcript::Transcript;
 use types::int_to_field_bits;
 use witness::{InstancePaddingStrategy, RowMajorMatrix};

--- a/crates/mpcs/src/jagged/mod.rs
+++ b/crates/mpcs/src/jagged/mod.rs
@@ -160,11 +160,9 @@ use multilinear_extensions::{
     util::ceil_log2,
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec},
 };
-#[cfg(feature = "parallel")]
-use p3::maybe_rayon::prelude::IndexedParallelIterator;
 use p3::{
     matrix::{Matrix, bitrev::BitReversableMatrix},
-    maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator, ParallelSliceMut},
+    maybe_rayon::prelude::*,
 };
 use transcript::Transcript;
 use types::int_to_field_bits;

--- a/crates/mpcs/src/jagged/sumcheck.rs
+++ b/crates/mpcs/src/jagged/sumcheck.rs
@@ -7,11 +7,7 @@ use ff_ext::ExtensionField;
 use multilinear_extensions::{
     mle::MultilinearExtension, util::max_usable_threads, virtual_poly::build_eq_x_r_vec,
 };
-#[cfg(feature = "parallel")]
-use p3::maybe_rayon::prelude::IndexedParallelIterator;
-use p3::maybe_rayon::prelude::{
-    IntoParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut,
-};
+use p3::maybe_rayon::prelude::*;
 use sumcheck::{
     macros::{entered_span, exit_span},
     structs::{IOPProof, IOPProverMessage, IOPProverState},

--- a/crates/mpcs/src/jagged/sumcheck.rs
+++ b/crates/mpcs/src/jagged/sumcheck.rs
@@ -7,9 +7,10 @@ use ff_ext::ExtensionField;
 use multilinear_extensions::{
     mle::MultilinearExtension, util::max_usable_threads, virtual_poly::build_eq_x_r_vec,
 };
+#[cfg(feature = "parallel")]
+use p3::maybe_rayon::prelude::IndexedParallelIterator;
 use p3::maybe_rayon::prelude::{
-    IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSlice,
-    ParallelSliceMut,
+    IntoParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut,
 };
 use sumcheck::{
     macros::{entered_span, exit_span},

--- a/crates/mpcs/src/jagged/types.rs
+++ b/crates/mpcs/src/jagged/types.rs
@@ -58,12 +58,15 @@ impl<E: ExtensionField, InnerPcs: PolynomialCommitmentScheme<E>>
 /// Proof for the jagged batch opening protocol.
 ///
 /// Contains a sumcheck proof (reducing K column evaluation claims to a single
-/// point on q'), the evaluation q'(ρ), and an inner PCS opening proof.
+/// point on q'), the evaluation q'(ρ), an assist sumcheck proof (reducing K
+/// ROBP evaluations to one), and an inner PCS opening proof.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "", deserialize = ""))]
 pub struct JaggedBatchOpenProof<E: ExtensionField, InnerPcs: PolynomialCommitmentScheme<E>> {
     pub sumcheck_proof: IOPProof<E>,
     pub q_eval: E,
+    pub f_at_rho: E,
+    pub assist_proof: IOPProof<E>,
     pub inner_proof: InnerPcs::Proof,
 }
 

--- a/crates/mpcs/src/lib.rs
+++ b/crates/mpcs/src/lib.rs
@@ -270,8 +270,8 @@ pub use basefold::{
 pub mod jagged;
 pub use jagged::{
     JaggedBatchOpenProof, JaggedCommitment, JaggedCommitmentWithWitness, JaggedSumcheckInput,
-    evaluate_g, evaluate_g_backward, evaluate_g_forward, jagged_batch_open, jagged_batch_verify,
-    jagged_commit, jagged_sumcheck_prove,
+    assist_sumcheck_prove, evaluate_g, evaluate_g_backward, evaluate_g_forward, jagged_batch_open,
+    jagged_batch_verify, jagged_commit, jagged_sumcheck_prove,
 };
 #[cfg(feature = "whir")]
 extern crate whir as whir_external;


### PR DESCRIPTION
## Summary

Fixes https://github.com/scroll-tech/ceno/issues/1290.

- Implements the assist sumcheck protocol (Lemma 5.1, eprint 2025/917) that batches K indicator function ĝ evaluations into a single opening via an ROBP-based forward-backward decomposition with interleaved variable ordering
- Integrates into `jagged_batch_open` / `jagged_batch_verify` so the verifier no longer needs K separate ROBP evaluations
- Parallelizes the round-polynomial computation: thread-local bwd_sum buckets + per-thread p(λ) evaluation, with only scalar sums across threads. Cached per-thread buckets are reused across both rounds of each ROBP step (no merge needed).

## Benchmark: assist sumcheck prover (BabyBearExt4, `--features parallel`)

| K | Time | ms / 1000 polys |
|---|---|---|
| 1,000 | 5.9 ms | 5.9 |
| 2,000 | 9.5 ms | 4.8 |
| 4,000 | 13.8 ms | 3.4 |
| 8,000 | 25.9 ms | 3.2 |
| 16,000 | 43.9 ms | 2.7 |

Step-major data layout + parallel round-polynomial computation — per-poly cost decreases with K due to better thread utilization.

## Test plan
- [x] All 20 existing jagged tests pass (`cargo test -p mpcs --lib jagged`)
- [x] 4 new assist sumcheck tests: small, single-poly, many-polys, forward-backward consistency
- [x] End-to-end batch open/verify tests still pass (assist sumcheck is now integrated)
- [x] Benchmark: `cargo bench -p mpcs --bench jagged_sumcheck --features parallel -- assist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)