### PR TITLE
ci: split test job into serial and parallel+SIMD steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,5 +42,10 @@ jobs:
       - name: Install cargo make
         run: |
           cargo make --version || cargo install cargo-make
-      - name: run test
+      - name: Test (serial)
+        run: cargo test --workspace --lib
+        env:
+          RUST_MIN_STACK: "33554432"
+
+      - name: Test (parallel + SIMD)
         run: cargo make tests


### PR DESCRIPTION
## Summary
- Split the single CI test step into two steps matching our deployment modes:
  - **Serial** (default features): client-side proving path
  - **Parallel + SIMD** (all features): server-side production path
- Both steps run in one job to share the cargo cache

## Test plan
- Merge and verify both CI steps pass on this PR's workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)