### PR TITLE
fix frontload bug and follow design rationales in PR 49

### DIFF
--- a/crates/sumcheck/src/frontload.rs
+++ b/crates/sumcheck/src/frontload.rs
@@ -168,6 +168,10 @@ pub fn prove_2phase<'a, E: ExtensionField>(
             WorkingState::new_with_metadata(
                 poly,
                 global_mle_num_vars.clone(),
+                frontload_poly_meta
+                    .iter()
+                    .map(|meta| *meta == FrontloadPolyMeta::Normal)
+                    .collect_vec(),
                 Some((worker_id, log_num_workers)),
             )
         })
@@ -324,6 +328,7 @@ struct WorkingState<'a, E: ExtensionField> {
     term_metadata: Vec<Vec<TermMetadata>>,
     challenges: Vec<Challenge<E>>,
     global_mle_num_vars: Vec<usize>,
+    mle_has_worker_bits: Vec<bool>,
     worker: Option<(usize, usize)>,
 }
 
@@ -343,12 +348,14 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
             .iter()
             .map(|mle| mle.num_vars())
             .collect_vec();
-        Self::new_with_metadata(poly, global_mle_num_vars, None)
+        let mle_has_worker_bits = vec![false; global_mle_num_vars.len()];
+        Self::new_with_metadata(poly, global_mle_num_vars, mle_has_worker_bits, None)
     }
 
     fn new_with_metadata(
         poly: VirtualPolynomial<'a, E>,
         global_mle_num_vars: Vec<usize>,
+        mle_has_worker_bits: Vec<bool>,
         worker: Option<(usize, usize)>,
     ) -> Self {
         let mles = poly
@@ -357,6 +364,7 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
             .map(|mle| mle.as_ref().as_owned())
             .collect_vec();
         assert_eq!(global_mle_num_vars.len(), mles.len());
+        assert_eq!(mle_has_worker_bits.len(), mles.len());
         let term_metadata = poly
             .products
             .iter()
@@ -403,6 +411,7 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
             term_metadata,
             challenges: vec![],
             global_mle_num_vars,
+            mle_has_worker_bits,
             worker,
         }
     }
@@ -663,13 +672,14 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
         let Some((worker_id, log_num_workers)) = self.worker else {
             return true;
         };
-        let local_num_vars = self.poly.aux_info.max_num_variables;
-        term_matches_frontload_tail(
-            local_num_vars,
-            &self.global_mle_num_vars,
-            Some((worker_id, log_num_workers)),
-            term,
-        )
+        if term
+            .product
+            .iter()
+            .any(|&idx| self.mle_has_worker_bits[idx])
+        {
+            return true;
+        }
+        worker_id == (1usize << log_num_workers) - 1
     }
 
     fn required_future_frontload_mask(
@@ -686,7 +696,7 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
             let needs_frontload = term
                 .product
                 .iter()
-                .any(|&idx| self.global_mle_num_vars[idx] <= var_idx);
+                .any(|&idx| self.frontload_tail_start(idx) <= var_idx);
             if needs_frontload {
                 mask | (1usize << (var_idx - round - 1))
             } else {
@@ -731,13 +741,21 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
     }
 
     fn fixed_frontload_factor(&self, mle_idx: usize, round: usize) -> E {
-        let original_num_vars = self.global_mle_num_vars[mle_idx];
-        if round <= original_num_vars {
+        let tail_start = self.frontload_tail_start(mle_idx);
+        if round <= tail_start {
             return E::ONE;
         }
-        self.challenges[original_num_vars..round]
+        self.challenges[tail_start..round]
             .iter()
             .fold(E::ONE, |acc, challenge| acc * challenge.elements)
+    }
+
+    fn frontload_tail_start(&self, mle_idx: usize) -> usize {
+        if self.worker.is_some() {
+            self.poly.flattened_ml_extensions[mle_idx].num_vars()
+        } else {
+            self.global_mle_num_vars[mle_idx]
+        }
     }
 
     fn fold_round(&mut self, challenge: E) {
@@ -783,7 +801,10 @@ fn build_phase2_poly<'a, E: ExtensionField>(
             FrontloadPolyMeta::Normal => {
                 let values = workers
                     .iter()
-                    .map(|worker| read_eval(&worker.mles[mle_idx], 0))
+                    .map(|worker| {
+                        read_eval(&worker.mles[mle_idx], 0)
+                            * worker.fixed_frontload_factor(mle_idx, local_num_vars)
+                    })
                     .collect_vec();
                 MultilinearExtension::from_evaluations_ext_vec(log_num_workers, values)
             }
@@ -857,27 +878,6 @@ fn ext_round_endpoints<E: ExtensionField>(
         evals.get(suffix << 1).copied().unwrap_or(E::ZERO),
         evals.get((suffix << 1) + 1).copied().unwrap_or(E::ZERO),
     )
-}
-
-fn term_matches_frontload_tail<E: ExtensionField>(
-    local_num_vars: usize,
-    global_mle_num_vars: &[usize],
-    worker: Option<(usize, usize)>,
-    term: &Term<either::Either<E::BaseField, E>, usize>,
-) -> bool {
-    let Some((worker_id, log_num_workers)) = worker else {
-        return true;
-    };
-    let term_num_vars = term
-        .product
-        .iter()
-        .map(|&idx| global_mle_num_vars[idx])
-        .max()
-        .unwrap_or(0);
-    (0..log_num_workers).all(|phase2_bit| {
-        let global_var = local_num_vars + phase2_bit;
-        term_num_vars > global_var || ((worker_id >> phase2_bit) & 1) == 1
-    })
 }
 
 fn scalar_to_ext<E: ExtensionField>(scalar: &either::Either<E::BaseField, E>) -> E {

--- a/crates/sumcheck/src/frontload.rs
+++ b/crates/sumcheck/src/frontload.rs
@@ -176,6 +176,9 @@ pub fn prove_2phase<'a, E: ExtensionField>(
             )
         })
         .collect_vec();
+    if let Some(worker) = workers.first() {
+        worker.assert_uniform_product_num_vars();
+    }
     let mut proofs = Vec::with_capacity(global_num_vars);
     let mut challenge: Option<Challenge<E>> = None;
 
@@ -829,6 +832,22 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
             })
     }
 
+    fn assert_uniform_product_num_vars(&self) {
+        for MonomialTerms { terms } in &self.poly.products {
+            for term in terms {
+                let Some((&first_idx, rest)) = term.product.split_first() else {
+                    continue;
+                };
+                let first_num_vars = self.global_mle_num_vars[first_idx];
+                assert!(
+                    rest.iter()
+                        .all(|&idx| self.global_mle_num_vars[idx] == first_num_vars),
+                    "frontload 2phase expects every MLE in a product term to have the same canonical num_vars"
+                );
+            }
+        }
+    }
+
     fn fold_round(&mut self, challenge: E) {
         let round = self.challenges.len() - 1;
         self.fold_round_at(round, challenge);
@@ -882,18 +901,14 @@ fn term_round_evaluations_across_workers<'a, E: ExtensionField>(
     round: usize,
 ) -> Vec<E> {
     let first_worker = workers.first().expect("frontload 2phase needs workers");
+    let Some(layout) = TermWorkerLayout::new(first_worker, term) else {
+        return workers
+            .last()
+            .expect("frontload 2phase needs workers")
+            .term_round_evaluations(term, round);
+    };
     let degree = term.product.len();
-    let phase1_num_vars = first_worker.poly.aux_info.max_num_variables;
-    let live_vars = term
-        .product
-        .iter()
-        .map(|&idx| {
-            first_worker.global_mle_num_vars[idx]
-                .min(phase1_num_vars)
-                .saturating_sub(round)
-        })
-        .max()
-        .unwrap_or(0);
+    let live_vars = layout.phase1_end.saturating_sub(round);
     let lane_count = if live_vars == 0 {
         1
     } else {
@@ -907,12 +922,14 @@ fn term_round_evaluations_across_workers<'a, E: ExtensionField>(
         for (z_idx, eval) in evaluations.iter_mut().enumerate() {
             let z = E::from_canonical_u64(z_idx as u64);
             let mut term_eval = E::ZERO;
-            for group_key in worker_future_group_keys(workers, term, round) {
+            for group_key in layout.future_group_keys(workers, round) {
                 let product = term
                     .product
                     .iter()
                     .map(|&idx| {
-                        canonical_worker_group_value(workers, idx, round, lane, z, group_key)
+                        canonical_worker_group_value(
+                            workers, layout, idx, round, lane, z, group_key,
+                        )
                     })
                     .product::<E>();
                 term_eval += product;
@@ -931,81 +948,100 @@ fn term_round_evaluations_across_workers<'a, E: ExtensionField>(
     }
 }
 
-fn worker_future_group_keys<'a, E: ExtensionField>(
-    workers: &[WorkingState<'a, E>],
-    term: &Term<either::Either<E::BaseField, E>, usize>,
-    round: usize,
-) -> Vec<usize> {
-    let first_worker = workers.first().expect("frontload 2phase needs workers");
-    let phase1_num_vars = first_worker.poly.aux_info.max_num_variables;
-    let mut keys = workers
-        .iter()
-        .map(|worker| {
-            term.product.iter().fold(0usize, |key, &mle_idx| {
-                if !first_worker.mle_has_worker_bits[mle_idx] {
-                    return key;
-                }
-                let local_num_vars = first_worker.poly.flattened_ml_extensions[mle_idx].num_vars();
-                let global_num_vars = first_worker.global_mle_num_vars[mle_idx];
-                (phase1_num_vars.max(round + 1).max(local_num_vars)..global_num_vars).fold(
-                    key,
-                    |key, var_idx| {
-                        key | (worker.worker_round_bit(mle_idx, var_idx)
-                            << (var_idx - phase1_num_vars))
-                    },
-                )
-            })
+#[derive(Clone, Copy)]
+struct TermWorkerLayout {
+    local_num_vars: usize,
+    global_num_vars: usize,
+    phase1_num_vars: usize,
+    phase1_end: usize,
+    first_mle_idx: usize,
+}
+
+impl TermWorkerLayout {
+    fn new<E: ExtensionField>(
+        worker: &WorkingState<'_, E>,
+        term: &Term<either::Either<E::BaseField, E>, usize>,
+    ) -> Option<Self> {
+        let first_mle_idx = term
+            .product
+            .iter()
+            .copied()
+            .find(|&idx| worker.mle_has_worker_bits[idx])?;
+        let local_num_vars = worker.poly.flattened_ml_extensions[first_mle_idx].num_vars();
+        let global_num_vars = worker.global_mle_num_vars[first_mle_idx];
+        let phase1_num_vars = worker.poly.aux_info.max_num_variables;
+        Some(Self {
+            local_num_vars,
+            global_num_vars,
+            phase1_num_vars,
+            phase1_end: global_num_vars.min(phase1_num_vars),
+            first_mle_idx,
         })
-        .collect_vec();
-    keys.sort_unstable();
-    keys.dedup();
-    if keys.is_empty() { vec![0] } else { keys }
+    }
+
+    fn future_group_keys<E: ExtensionField>(
+        self,
+        workers: &[WorkingState<'_, E>],
+        round: usize,
+    ) -> Vec<usize> {
+        let group_start = self.phase1_num_vars.max(round + 1).max(self.local_num_vars);
+        if group_start >= self.global_num_vars {
+            return vec![0];
+        }
+
+        let mut keys = workers
+            .iter()
+            .map(|worker| {
+                (group_start..self.global_num_vars).fold(0usize, |key, var_idx| {
+                    key | (worker.worker_round_bit(self.first_mle_idx, var_idx)
+                        << (var_idx - self.phase1_num_vars))
+                })
+            })
+            .collect_vec();
+        keys.sort_unstable();
+        keys.dedup();
+        keys
+    }
 }
 
 fn canonical_worker_group_value<'a, E: ExtensionField>(
     workers: &[WorkingState<'a, E>],
+    layout: TermWorkerLayout,
     mle_idx: usize,
     round: usize,
     lane: usize,
     z: E,
     group_key: usize,
 ) -> E {
-    let first_worker = workers.first().expect("frontload 2phase needs workers");
-    if !first_worker.mle_has_worker_bits[mle_idx] {
-        return first_worker.mle_round_value(mle_idx, round, lane, z)
-            * first_worker.fixed_frontload_factor(mle_idx, round);
-    }
-
-    let local_num_vars = first_worker.poly.flattened_ml_extensions[mle_idx].num_vars();
-    let global_num_vars = first_worker.global_mle_num_vars[mle_idx];
-    let phase1_num_vars = first_worker.poly.aux_info.max_num_variables;
-
     workers
         .iter()
         .filter_map(|worker| {
-            for var_idx in phase1_num_vars.max(round + 1).max(local_num_vars)..global_num_vars {
-                let group_bit = (group_key >> (var_idx - phase1_num_vars)) & 1;
+            for var_idx in layout
+                .phase1_num_vars
+                .max(round + 1)
+                .max(layout.local_num_vars)..layout.global_num_vars
+            {
+                let group_bit = (group_key >> (var_idx - layout.phase1_num_vars)) & 1;
                 if worker.worker_round_bit(mle_idx, var_idx) != group_bit {
                     return None;
                 }
             }
 
-            let future_data_end = global_num_vars.min(phase1_num_vars);
-            for var_idx in local_num_vars.max(round + 1)..future_data_end {
+            for var_idx in layout.local_num_vars.max(round + 1)..layout.phase1_end {
                 let lane_bit = (lane >> (var_idx - round - 1)) & 1;
                 if worker.worker_round_bit(mle_idx, var_idx) != lane_bit {
                     return None;
                 }
             }
 
-            if round < local_num_vars {
+            if round < layout.local_num_vars {
                 return Some(
                     worker.mle_round_value(mle_idx, round, lane, z)
                         * worker.fixed_frontload_factor(mle_idx, round),
                 );
             }
 
-            let current_factor = if round < global_num_vars {
+            let current_factor = if round < layout.global_num_vars {
                 if worker.worker_round_bit(mle_idx, round) == 0 {
                     E::ONE - z
                 } else {

--- a/crates/sumcheck/src/frontload.rs
+++ b/crates/sumcheck/src/frontload.rs
@@ -180,24 +180,31 @@ pub fn prove_2phase<'a, E: ExtensionField>(
     let mut challenge: Option<Challenge<E>> = None;
 
     for round in 0..local_num_vars {
-        let mut evaluations = workers
-            .par_iter_mut()
-            .map(|worker| {
-                if let Some(challenge) = challenge {
-                    worker.challenges.push(challenge);
-                    worker.fold_round(challenge.elements);
-                }
-                worker.round_evaluations(round)
-            })
-            .reduce(
-                || vec![E::ZERO; max_degree + 1],
-                |mut acc, evals| {
-                    acc.iter_mut().zip_eq(evals).for_each(|(acc, eval)| {
-                        *acc += eval;
-                    });
-                    acc
-                },
-            );
+        workers.par_iter_mut().for_each(|worker| {
+            if let Some(challenge) = challenge {
+                worker.challenges.push(challenge);
+                worker.fold_round(challenge.elements);
+            }
+        });
+        let mut evaluations = if workers
+            .first()
+            .is_some_and(|worker| worker.any_mle_round_needs_canonical_merge(round))
+        {
+            round_evaluations_across_workers(&workers, round, max_degree)
+        } else {
+            workers
+                .par_iter()
+                .map(|worker| worker.round_evaluations(round))
+                .reduce(
+                    || vec![E::ZERO; max_degree + 1],
+                    |mut acc, evals| {
+                        acc.iter_mut().zip_eq(evals).for_each(|(acc, eval)| {
+                            *acc += eval;
+                        });
+                        acc
+                    },
+                )
+        };
         evaluations.remove(0);
         transcript.append_field_element_exts(&evaluations);
         proofs.push(IOPProverMessage { evaluations });
@@ -607,13 +614,39 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
         if !self.worker_matches_frontload_tail(term) {
             return vec![E::ZERO; self.poly.aux_info.max_degree + 1];
         }
-        match degree {
-            1 => return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(1, self, term, round),
-            2 => return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(2, self, term, round),
-            3 => return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(3, self, term, round),
-            4 => return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(4, self, term, round),
-            5 => return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(5, self, term, round),
-            _ => {}
+        let has_worker_bit_round = term
+            .product
+            .iter()
+            .any(|&idx| self.mle_round_is_worker_bit(idx, round));
+        if !has_worker_bit_round {
+            match degree {
+                1 => {
+                    return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(
+                        1, self, term, round
+                    );
+                }
+                2 => {
+                    return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(
+                        2, self, term, round
+                    );
+                }
+                3 => {
+                    return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(
+                        3, self, term, round
+                    );
+                }
+                4 => {
+                    return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(
+                        4, self, term, round
+                    );
+                }
+                5 => {
+                    return sumcheck_macro::frontload_mixed_sumcheck_code_gen!(
+                        5, self, term, round
+                    );
+                }
+                _ => {}
+            }
         }
 
         let live_vars = term
@@ -722,12 +755,21 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
     }
 
     fn mle_round_endpoints(&self, mle_idx: usize, round: usize, lane: usize) -> (E, E) {
-        let original_num_vars = self.poly.flattened_ml_extensions[mle_idx].num_vars();
-        if round >= original_num_vars {
-            return (E::ZERO, read_eval_or_zero(&self.mles[mle_idx], 0));
+        let local_num_vars = self.poly.flattened_ml_extensions[mle_idx].num_vars();
+        let global_num_vars = self.global_mle_num_vars[mle_idx];
+        if round >= local_num_vars {
+            let value = read_eval_or_zero(&self.mles[mle_idx], 0);
+            if round < global_num_vars {
+                return if self.worker_round_bit(mle_idx, round) == 0 {
+                    (value, E::ZERO)
+                } else {
+                    (E::ZERO, value)
+                };
+            }
+            return (E::ZERO, value);
         }
 
-        let remaining_vars = original_num_vars - round;
+        let remaining_vars = local_num_vars - round;
         let suffix_mask = if remaining_vars == 1 {
             0
         } else {
@@ -741,21 +783,50 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
     }
 
     fn fixed_frontload_factor(&self, mle_idx: usize, round: usize) -> E {
-        let tail_start = self.frontload_tail_start(mle_idx);
-        if round <= tail_start {
+        let local_num_vars = self.poly.flattened_ml_extensions[mle_idx].num_vars();
+        let global_num_vars = self.global_mle_num_vars[mle_idx];
+        if round <= local_num_vars {
             return E::ONE;
         }
-        self.challenges[tail_start..round]
-            .iter()
-            .fold(E::ONE, |acc, challenge| acc * challenge.elements)
+        (local_num_vars..round).fold(E::ONE, |acc, fixed_round| {
+            let challenge = self.challenges[fixed_round].elements;
+            if fixed_round < global_num_vars {
+                if self.worker_round_bit(mle_idx, fixed_round) == 0 {
+                    acc * (E::ONE - challenge)
+                } else {
+                    acc * challenge
+                }
+            } else {
+                acc * challenge
+            }
+        })
     }
 
     fn frontload_tail_start(&self, mle_idx: usize) -> usize {
-        if self.worker.is_some() {
-            self.poly.flattened_ml_extensions[mle_idx].num_vars()
-        } else {
-            self.global_mle_num_vars[mle_idx]
-        }
+        self.global_mle_num_vars[mle_idx]
+    }
+
+    fn mle_round_is_worker_bit(&self, mle_idx: usize, round: usize) -> bool {
+        self.worker.is_some()
+            && self.mle_has_worker_bits[mle_idx]
+            && round >= self.poly.flattened_ml_extensions[mle_idx].num_vars()
+            && round < self.global_mle_num_vars[mle_idx]
+    }
+
+    fn worker_round_bit(&self, mle_idx: usize, round: usize) -> usize {
+        let local_num_vars = self.poly.flattened_ml_extensions[mle_idx].num_vars();
+        debug_assert!(round >= local_num_vars);
+        self.worker
+            .map(|(worker_id, _log_num_workers)| (worker_id >> (round - local_num_vars)) & 1)
+            .unwrap_or(1)
+    }
+
+    fn any_mle_round_needs_canonical_merge(&self, round: usize) -> bool {
+        self.worker.is_some()
+            && (0..self.mles.len()).any(|mle_idx| {
+                self.mle_has_worker_bits[mle_idx]
+                    && round >= self.poly.flattened_ml_extensions[mle_idx].num_vars()
+            })
     }
 
     fn fold_round(&mut self, challenge: E) {
@@ -786,6 +857,173 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
     }
 }
 
+fn round_evaluations_across_workers<'a, E: ExtensionField>(
+    workers: &[WorkingState<'a, E>],
+    round: usize,
+    max_degree: usize,
+) -> Vec<E> {
+    let first_worker = workers.first().expect("frontload 2phase needs workers");
+    let mut evaluations = vec![E::ZERO; max_degree + 1];
+    for MonomialTerms { terms } in &first_worker.poly.products {
+        for term in terms {
+            let term_evaluations = term_round_evaluations_across_workers(workers, term, round);
+            evaluations
+                .iter_mut()
+                .zip_eq(term_evaluations)
+                .for_each(|(acc, eval)| *acc += eval);
+        }
+    }
+    evaluations
+}
+
+fn term_round_evaluations_across_workers<'a, E: ExtensionField>(
+    workers: &[WorkingState<'a, E>],
+    term: &Term<either::Either<E::BaseField, E>, usize>,
+    round: usize,
+) -> Vec<E> {
+    let first_worker = workers.first().expect("frontload 2phase needs workers");
+    let degree = term.product.len();
+    let phase1_num_vars = first_worker.poly.aux_info.max_num_variables;
+    let live_vars = term
+        .product
+        .iter()
+        .map(|&idx| {
+            first_worker.global_mle_num_vars[idx]
+                .min(phase1_num_vars)
+                .saturating_sub(round)
+        })
+        .max()
+        .unwrap_or(0);
+    let lane_count = if live_vars == 0 {
+        1
+    } else {
+        1usize << (live_vars - 1)
+    };
+    let required_ones_mask = first_worker.required_future_frontload_mask(term, round, live_vars);
+    let scalar = scalar_to_ext(&term.scalar);
+    let mut evaluations = vec![E::ZERO; degree + 1];
+
+    for_each_active_lane(lane_count, required_ones_mask, |lane| {
+        for (z_idx, eval) in evaluations.iter_mut().enumerate() {
+            let z = E::from_canonical_u64(z_idx as u64);
+            let mut term_eval = E::ZERO;
+            for group_key in worker_future_group_keys(workers, term, round) {
+                let product = term
+                    .product
+                    .iter()
+                    .map(|&idx| {
+                        canonical_worker_group_value(workers, idx, round, lane, z, group_key)
+                    })
+                    .product::<E>();
+                term_eval += product;
+            }
+            *eval += term_eval * scalar;
+        }
+    });
+
+    if degree == first_worker.poly.aux_info.max_degree {
+        evaluations
+    } else {
+        let mut extrapolated = vec![E::ZERO; first_worker.poly.aux_info.max_degree + 1];
+        extrapolated[..=degree].copy_from_slice(&evaluations);
+        extrapolate_from_table(&mut extrapolated, degree + 1);
+        extrapolated
+    }
+}
+
+fn worker_future_group_keys<'a, E: ExtensionField>(
+    workers: &[WorkingState<'a, E>],
+    term: &Term<either::Either<E::BaseField, E>, usize>,
+    round: usize,
+) -> Vec<usize> {
+    let first_worker = workers.first().expect("frontload 2phase needs workers");
+    let phase1_num_vars = first_worker.poly.aux_info.max_num_variables;
+    let mut keys = workers
+        .iter()
+        .map(|worker| {
+            term.product.iter().fold(0usize, |key, &mle_idx| {
+                if !first_worker.mle_has_worker_bits[mle_idx] {
+                    return key;
+                }
+                let local_num_vars = first_worker.poly.flattened_ml_extensions[mle_idx].num_vars();
+                let global_num_vars = first_worker.global_mle_num_vars[mle_idx];
+                (phase1_num_vars.max(round + 1).max(local_num_vars)..global_num_vars).fold(
+                    key,
+                    |key, var_idx| {
+                        key | (worker.worker_round_bit(mle_idx, var_idx)
+                            << (var_idx - phase1_num_vars))
+                    },
+                )
+            })
+        })
+        .collect_vec();
+    keys.sort_unstable();
+    keys.dedup();
+    if keys.is_empty() { vec![0] } else { keys }
+}
+
+fn canonical_worker_group_value<'a, E: ExtensionField>(
+    workers: &[WorkingState<'a, E>],
+    mle_idx: usize,
+    round: usize,
+    lane: usize,
+    z: E,
+    group_key: usize,
+) -> E {
+    let first_worker = workers.first().expect("frontload 2phase needs workers");
+    if !first_worker.mle_has_worker_bits[mle_idx] {
+        return first_worker.mle_round_value(mle_idx, round, lane, z)
+            * first_worker.fixed_frontload_factor(mle_idx, round);
+    }
+
+    let local_num_vars = first_worker.poly.flattened_ml_extensions[mle_idx].num_vars();
+    let global_num_vars = first_worker.global_mle_num_vars[mle_idx];
+    let phase1_num_vars = first_worker.poly.aux_info.max_num_variables;
+
+    workers
+        .iter()
+        .filter_map(|worker| {
+            for var_idx in phase1_num_vars.max(round + 1).max(local_num_vars)..global_num_vars {
+                let group_bit = (group_key >> (var_idx - phase1_num_vars)) & 1;
+                if worker.worker_round_bit(mle_idx, var_idx) != group_bit {
+                    return None;
+                }
+            }
+
+            let future_data_end = global_num_vars.min(phase1_num_vars);
+            for var_idx in local_num_vars.max(round + 1)..future_data_end {
+                let lane_bit = (lane >> (var_idx - round - 1)) & 1;
+                if worker.worker_round_bit(mle_idx, var_idx) != lane_bit {
+                    return None;
+                }
+            }
+
+            if round < local_num_vars {
+                return Some(
+                    worker.mle_round_value(mle_idx, round, lane, z)
+                        * worker.fixed_frontload_factor(mle_idx, round),
+                );
+            }
+
+            let current_factor = if round < global_num_vars {
+                if worker.worker_round_bit(mle_idx, round) == 0 {
+                    E::ONE - z
+                } else {
+                    z
+                }
+            } else {
+                z
+            };
+
+            Some(
+                read_eval(&worker.mles[mle_idx], 0)
+                    * worker.fixed_frontload_factor(mle_idx, round)
+                    * current_factor,
+            )
+        })
+        .sum()
+}
+
 fn build_phase2_poly<'a, E: ExtensionField>(
     workers: &[WorkingState<'a, E>],
     poly_meta: &[FrontloadPolyMeta],
@@ -797,16 +1035,28 @@ fn build_phase2_poly<'a, E: ExtensionField>(
     poly.aux_info.max_degree = first_worker.poly.aux_info.max_degree;
 
     for (mle_idx, meta) in poly_meta.iter().enumerate() {
+        let global_num_vars = first_worker.global_mle_num_vars[mle_idx];
         let mle = match meta {
             FrontloadPolyMeta::Normal => {
-                let values = workers
-                    .iter()
-                    .map(|worker| {
-                        read_eval(&worker.mles[mle_idx], 0)
-                            * worker.fixed_frontload_factor(mle_idx, local_num_vars)
-                    })
-                    .collect_vec();
-                MultilinearExtension::from_evaluations_ext_vec(log_num_workers, values)
+                if global_num_vars <= local_num_vars {
+                    let value = workers
+                        .iter()
+                        .map(|worker| {
+                            read_eval(&worker.mles[mle_idx], 0)
+                                * worker.fixed_frontload_factor(mle_idx, local_num_vars)
+                        })
+                        .sum();
+                    MultilinearExtension::from_evaluations_ext_vec(0, vec![value])
+                } else {
+                    let values = workers
+                        .iter()
+                        .map(|worker| {
+                            read_eval(&worker.mles[mle_idx], 0)
+                                * worker.fixed_frontload_factor(mle_idx, local_num_vars)
+                        })
+                        .collect_vec();
+                    MultilinearExtension::from_evaluations_ext_vec(log_num_workers, values)
+                }
             }
             FrontloadPolyMeta::Phase1Only => {
                 let value = read_eval(&first_worker.mles[mle_idx], 0)

--- a/crates/sumcheck/src/test.rs
+++ b/crates/sumcheck/src/test.rs
@@ -76,6 +76,8 @@ fn test_frontload_2phase_sum_keeps_small_mle_compact() {
     let large = multilinear_extensions::mle::MultilinearExtension::<GoldilocksExt2>::random(
         num_vars, &mut rng,
     );
+    let medium =
+        multilinear_extensions::mle::MultilinearExtension::<GoldilocksExt2>::random(5, &mut rng);
     let small =
         multilinear_extensions::mle::MultilinearExtension::<GoldilocksExt2>::random(2, &mut rng);
     let poly = VirtualPolynomials::new_from_monimials(
@@ -85,6 +87,10 @@ fn test_frontload_2phase_sum_keeps_small_mle_compact() {
             Term {
                 scalar: Either::Right(GoldilocksExt2::ONE),
                 product: vec![Either::Left(&large)],
+            },
+            Term {
+                scalar: Either::Right(GoldilocksExt2::ONE),
+                product: vec![Either::Left(&medium)],
             },
             Term {
                 scalar: Either::Right(GoldilocksExt2::ONE),
@@ -99,6 +105,7 @@ fn test_frontload_2phase_sum_keeps_small_mle_compact() {
 
     let mut direct_poly = VirtualPolynomial::new(num_vars);
     let large_idx = direct_poly.register_mle(Arc::new(large));
+    let medium_idx = direct_poly.register_mle(Arc::new(medium));
     let small_idx = direct_poly.register_mle(Arc::new(small));
     direct_poly.aux_info.max_degree = 1;
     direct_poly
@@ -108,6 +115,10 @@ fn test_frontload_2phase_sum_keeps_small_mle_compact() {
                 Term {
                     scalar: Either::Right(GoldilocksExt2::ONE),
                     product: vec![large_idx],
+                },
+                Term {
+                    scalar: Either::Right(GoldilocksExt2::ONE),
+                    product: vec![medium_idx],
                 },
                 Term {
                     scalar: Either::Right(GoldilocksExt2::ONE),
@@ -211,6 +222,27 @@ fn test_random_monimials_use_frontload_sum() {
         &mut rng,
     );
     let max_num_variables = *nv.iter().max().unwrap();
+
+    // Build a single-worker VirtualPolynomial for natural frontload evaluation check.
+    // Must be built before the mutable borrow in new_from_monimials below.
+    let mut direct_poly = VirtualPolynomial::new(max_num_variables);
+    direct_poly.aux_info.max_degree = degree;
+    for term in &monimials {
+        let indices: Vec<usize> = term
+            .product
+            .iter()
+            .map(|mle| direct_poly.register_mle(Arc::new(mle.clone())))
+            .collect_vec();
+        direct_poly
+            .products
+            .push(multilinear_extensions::virtual_poly::MonomialTerms {
+                terms: vec![Term {
+                    scalar: Either::Right(term.scalar),
+                    product: indices,
+                }],
+            });
+    }
+
     let poly = VirtualPolynomials::<GoldilocksExt2>::new_from_monimials(
         4,
         max_num_variables,
@@ -243,8 +275,10 @@ fn test_random_monimials_use_frontload_sum() {
         .map(|challenge| challenge.elements)
         .collect_vec();
     assert_eq!(
-        worker_aware_frontload_evaluate(4, max_num_variables, &monimials, &point),
-        subclaim.expected_evaluation
+        frontload::evaluate(&direct_poly, &point),
+        subclaim.expected_evaluation,
+        "frontload 2phase final evaluation mismatch: natural frontload evaluation \
+         must agree with the verifier's expected evaluation"
     );
 }
 
@@ -312,52 +346,39 @@ fn test_frontload_2phase_mle_category_combinations() {
             .iter()
             .map(|challenge| challenge.elements)
             .collect_vec();
+        let mut direct_poly = VirtualPolynomial::new(max_num_variables);
+        direct_poly.aux_info.max_degree = degree;
+        for Term { scalar, product } in &monomials {
+            let indices = product
+                .iter()
+                .map(|mle| direct_poly.register_mle(Arc::new(mle.clone())))
+                .collect_vec();
+            direct_poly
+                .products
+                .push(multilinear_extensions::virtual_poly::MonomialTerms {
+                    terms: vec![Term {
+                        scalar: Either::Right(*scalar),
+                        product: indices,
+                    }],
+                });
+        }
+        let mut direct_transcript =
+            BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
+        let (direct_proof, _) = frontload::prove(direct_poly.as_view(), &mut direct_transcript);
+        for (round, (direct, two_phase)) in
+            direct_proof.proofs.iter().zip(&proof.proofs).enumerate()
+        {
+            assert_eq!(
+                direct, two_phase,
+                "frontload 2phase diverged at round {round} for {selected_names}"
+            );
+        }
         assert_eq!(
-            worker_aware_frontload_evaluate(num_threads, max_num_variables, &monomials, &point),
+            frontload::evaluate(&direct_poly, &point),
             subclaim.expected_evaluation,
             "frontload 2phase failed for {selected_names}"
         );
     }
-}
-
-fn worker_aware_frontload_evaluate<E: ExtensionField>(
-    num_threads: usize,
-    max_num_variables: usize,
-    monomials: &[Term<E, MultilinearExtension<'_, E>>],
-    point: &[E],
-) -> E {
-    let log_num_workers = p3::util::log2_strict_usize(num_threads);
-    let local_num_vars = max_num_variables - log_num_workers;
-    monomials
-        .iter()
-        .map(|Term { scalar, product }| {
-            product
-                .iter()
-                .map(|mle| {
-                    let mle_num_vars = mle.num_vars();
-                    if mle_num_vars > log_num_workers {
-                        let local_real_vars = mle_num_vars - log_num_workers;
-                        let mle_point = point[..local_real_vars]
-                            .iter()
-                            .chain(&point[local_num_vars..max_num_variables])
-                            .copied()
-                            .collect_vec();
-                        let local_tail = point[local_real_vars..local_num_vars]
-                            .iter()
-                            .copied()
-                            .product::<E>();
-                        mle.evaluate(&mle_point) * local_tail
-                    } else {
-                        let local_eval = mle.evaluate(&point[..mle_num_vars]);
-                        point[mle_num_vars..max_num_variables]
-                            .iter()
-                            .fold(local_eval, |acc, point| acc * *point)
-                    }
-                })
-                .product::<E>()
-                * *scalar
-        })
-        .sum()
 }
 
 // test polynomial mixed with different num_var

--- a/crates/sumcheck/src/test.rs
+++ b/crates/sumcheck/src/test.rs
@@ -14,7 +14,7 @@ use multilinear_extensions::{
     virtual_polys::VirtualPolynomials,
 };
 use p3::field::FieldAlgebra;
-use rand::{Rng, thread_rng};
+use rand::{Rng, SeedableRng, rngs::StdRng, thread_rng};
 use std::sync::Arc;
 use transcript::{BasicTranscript, Transcript};
 
@@ -204,7 +204,7 @@ fn test_random_monimials_use_frontload_sum() {
     let nv = vec![2, 4, 6];
     let degree = 2;
     let num_products = 2;
-    let (mut monimials, asserted_sum) = VirtualPolynomials::<GoldilocksExt2>::random_monimials(
+    let (monimials, asserted_sum) = VirtualPolynomials::<GoldilocksExt2>::random_monimials(
         &nv,
         (degree, degree + 1),
         num_products,
@@ -215,10 +215,10 @@ fn test_random_monimials_use_frontload_sum() {
         4,
         max_num_variables,
         monimials
-            .iter_mut()
+            .iter()
             .map(|Term { scalar, product }| Term {
                 scalar: Either::Right(*scalar),
-                product: product.iter_mut().map(Either::Right).collect_vec(),
+                product: product.iter().map(Either::Left).collect_vec(),
             })
             .collect_vec(),
     );
@@ -237,6 +237,127 @@ fn test_random_monimials_use_frontload_sum() {
         &mut transcript,
     );
     assert_eq!(subclaim.point.len(), max_num_variables);
+    let point = subclaim
+        .point
+        .iter()
+        .map(|challenge| challenge.elements)
+        .collect_vec();
+    assert_eq!(
+        worker_aware_frontload_evaluate(4, max_num_variables, &monimials, &point),
+        subclaim.expected_evaluation
+    );
+}
+
+#[test]
+fn test_frontload_2phase_mle_category_combinations() {
+    let cases = [
+        ("phase1_only", 2),
+        ("normal_exhausted_with_tail", 3),
+        ("normal_exhausted_at_phase1_end", 4),
+        ("normal_not_exhausted", 6),
+    ];
+    let degree = 2;
+    let max_num_variables = 6;
+    let num_threads = 4;
+    let mut rng = StdRng::seed_from_u64(50);
+
+    for mask in 1usize..(1 << cases.len()) {
+        let selected = cases
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| ((mask >> idx) & 1) == 1)
+            .collect_vec();
+        let mut asserted_sum = GoldilocksExt2::ZERO;
+        let monomials = selected
+            .iter()
+            .map(|(_, (_, num_variables))| {
+                let (product, product_sum) =
+                    MultilinearExtension::random_mle_list(*num_variables, degree, &mut rng);
+                let scalar = GoldilocksExt2::random(&mut rng);
+                asserted_sum += product_sum * scalar;
+                Term { scalar, product }
+            })
+            .collect_vec();
+
+        let poly = VirtualPolynomials::<GoldilocksExt2>::new_from_monimials(
+            num_threads,
+            max_num_variables,
+            monomials
+                .iter()
+                .map(|Term { scalar, product }| Term {
+                    scalar: Either::Right(*scalar),
+                    product: product.iter().map(Either::Left).collect_vec(),
+                })
+                .collect_vec(),
+        );
+
+        let mut transcript =
+            BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
+        let (proof, _) = IOPProverState::<GoldilocksExt2>::prove(poly, &mut transcript);
+        let selected_names = selected.iter().map(|(_, (name, _))| *name).join(", ");
+        let mut transcript =
+            BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
+        let subclaim = IOPVerifierState::<GoldilocksExt2>::verify(
+            asserted_sum,
+            &proof,
+            &VPAuxInfo {
+                max_degree: degree,
+                max_num_variables,
+                ..Default::default()
+            },
+            &mut transcript,
+        );
+        let point = subclaim
+            .point
+            .iter()
+            .map(|challenge| challenge.elements)
+            .collect_vec();
+        assert_eq!(
+            worker_aware_frontload_evaluate(num_threads, max_num_variables, &monomials, &point),
+            subclaim.expected_evaluation,
+            "frontload 2phase failed for {selected_names}"
+        );
+    }
+}
+
+fn worker_aware_frontload_evaluate<E: ExtensionField>(
+    num_threads: usize,
+    max_num_variables: usize,
+    monomials: &[Term<E, MultilinearExtension<'_, E>>],
+    point: &[E],
+) -> E {
+    let log_num_workers = p3::util::log2_strict_usize(num_threads);
+    let local_num_vars = max_num_variables - log_num_workers;
+    monomials
+        .iter()
+        .map(|Term { scalar, product }| {
+            product
+                .iter()
+                .map(|mle| {
+                    let mle_num_vars = mle.num_vars();
+                    if mle_num_vars > log_num_workers {
+                        let local_real_vars = mle_num_vars - log_num_workers;
+                        let mle_point = point[..local_real_vars]
+                            .iter()
+                            .chain(&point[local_num_vars..max_num_variables])
+                            .copied()
+                            .collect_vec();
+                        let local_tail = point[local_real_vars..local_num_vars]
+                            .iter()
+                            .copied()
+                            .product::<E>();
+                        mle.evaluate(&mle_point) * local_tail
+                    } else {
+                        let local_eval = mle.evaluate(&point[..mle_num_vars]);
+                        point[mle_num_vars..max_num_variables]
+                            .iter()
+                            .fold(local_eval, |acc, point| acc * *point)
+                    }
+                })
+                .product::<E>()
+                * *scalar
+        })
+        .sum()
 }
 
 // test polynomial mixed with different num_var


### PR DESCRIPTION
## Problem
Credited to @kunxian-xia for give a concrete math behind the scene and reported in #50 and #52 💯 

Issue #50 reported that frontload two-phase sumcheck handled medium-size `Normal` MLEs incorrectly.

A medium `Normal` MLE is larger than the worker space, so it is split across workers, but its local worker chunk can exhaust before phase 1 ends. The original bug was that once a local chunk exhausted, the prover treated later canonical variables as simple frontload tail factors. That is wrong when those canonical variables are actually encoded by the worker id bits.

A later intermediate fix made the prover and tests agree by using a worker-layout-aware verifier oracle. That was also wrong: it changed the checked polynomial from canonical

```text
e(x0, ..., x{k-1}) * product_{i=k}^{N-1} x_i
```

to a prover-layout-dependent form where worker bits were moved to the end. The verifier must not know the prover's worker split.

## Design Rationale

This PR keeps the PR #49 prover workflow while restoring the canonical verifier polynomial.

### Canonical 2-Phase Rule

The prover still splits large MLE slices across workers without zero padding:

```text
global variables:  x0..x{N-1}
phase-1 variables: x0..x{N-w-1}
phase-2 variables: x{N-w}..x{N-1}
w = log2(num_workers)
```

For a split `Normal` MLE with `k` canonical variables, each worker owns a chunk with `k-w` local variables. When phase 1 reaches a canonical variable that is stored in the worker id, the prover contributes an equality factor for that worker bit:

```text
worker bit b at canonical round r:
  contribution at z = scalar * eq(z, b)
  eq(z, 0) = 1 - z
  eq(z, 1) = z
```

Only rounds `r >= k` are true frontload tail rounds and contribute `scalar * z`.

For product terms, worker-bit variables that are still unbound must stay correlated across all factors in the term. The implementation groups workers by still-unbound future worker bits, folds already-bound worker bits independently per MLE, and sums the grouped term contribution. This preserves the canonical product polynomial rather than the pointwise product over storage lanes.

### Same-Num-Vars Product Invariant

`VirtualPolynomials::new_from_monimials` already enforces that every MLE inside one product term has the same `num_vars`. This PR makes that assumption explicit in the frontload two-phase path and uses it to simplify the worker merge logic.

For a product term, all factors now share one `TermWorkerLayout`:

```text
local_num_vars  = k - w
global_num_vars = k
phase1_end      = min(k, N - w)
```

That means a term has one shared worker-bit schedule. The prover no longer needs generic per-MLE future grouping. It can compute the future worker-bit group once per term, then evaluate each factor under that same layout.

This keeps the implementation closer to the actual protocol invariant and avoids over-general code for mixed-size product terms that cannot be produced by the current constructor.

### Phase 2 Rule

At the phase boundary:

- `Normal` MLEs whose canonical variables are fully bound in phase 1 are collapsed to compact constants by summing worker contributions with accumulated equality/tail factors.
- `Normal` MLEs that still have phase-2 canonical variables are kept as worker-index MLEs.
- `Phase1Only` MLEs stay compact constants with normal frontload tail behavior.

The verifier remains canonical and only checks:

```text
e(x0..x{k-1}) * product_{i=k}^{N-1} x_i
```

It does not need to know worker count, worker-bit placement, or prover chunk layout.

### Why This Is Mathematically Correct

Let the global sumcheck have `N` variables and `w = log2(num_workers)`. A split `Normal` MLE `e` has `k` canonical variables and each worker stores a chunk indexed by worker id `b ∈ {0,1}^w`:

```text
e_b(y0, ..., y{k-w-1}) = e(y0, ..., y{k-w-1}, b0, ..., b{w-1})
```

The canonical verifier polynomial is still:

```text
E(x0, ..., x{N-1}) = e(x0, ..., x{k-1}) * product_{i=k}^{N-1} x_i
```

For any canonical worker-bit variable `x_r` where `k-w <= r < k`, write `h = r - (k-w)`. The MLE decomposes by worker-bit interpolation:

```text
e(x0, ..., x{k-1})
  = sum_{b ∈ {0,1}^w}
      e_b(x0, ..., x{k-w-1})
      * product_{h=0}^{w-1} eq(x{k-w+h}, b_h)
```

where:

```text
eq(x, 0) = 1 - x
eq(x, 1) = x
```

So when phase 1 reaches a worker-bit canonical round, the correct local contribution from worker `b` is not a tail factor `x`; it is `eq(x, b_h)`. Summing all workers reconstructs the same canonical MLE evaluation by the interpolation identity above. Only variables `x_i` with `i >= k` are true frontload tail variables and use factor `x_i`.

This is why the verifier remains canonical: the prover's worker split is only an internal decomposition of the same multilinear extension.

### Term With One MLE Factor

For `term product = 1`, the phase-1 round polynomial is directly the sum over workers:

```text
sum_b e_b(local variables) * bound_eq_factors(b) * current_factor_b(z) * tail_factors
```

At a worker-bit round, `current_factor_b(z) = eq(z, b_h)`. At a true tail round, `current_factor_b(z) = z`.

After the last canonical variable of `e` is bound, the remaining value is:

```text
sum_b e_b(r0, ..., r{k-w-1}) * product_h eq(r{k-w+h}, b_h)
```

which is exactly `e(r0, ..., r{k-1})`. From that point onward, only canonical frontload tail factors remain.

### Term With Multiple MLE Factors

For `term product > 1`, the polynomial is a product of canonical MLEs with the same `k`:

```text
P(x) = c * product_j e_j(x0, ..., x{k-1}) * product_{i=k}^{N-1} x_i
```

Since all factors in the term share `k`, they also share the same local chunk size and worker-bit rounds. The important rule is:

- worker bits already bound by previous challenges are folded independently into each MLE factor;
- worker bits that are still future variables remain correlated across all factors in the same term.

The implementation groups workers by the still-unbound future worker-bit assignment once per term. For each group, it computes each factor's folded value by summing workers consistent with the current lane/group, multiplies those factor values, then sums over groups:

```text
sum_future_group
  product_j (
    sum_{b consistent with group}
      e_{j,b}(...) * bound_eq_factors_j(b) * current_or_lane_factor_j(b)
  )
```

This matches the canonical product polynomial after partial variable binding. It avoids the incorrect storage-lane product:

```text
sum_b product_j e_{j,b}(...)
```

which would wrongly correlate independent canonical MLE evaluations through the prover's worker id. The grouping is only a prover-side way to evaluate the canonical round polynomial without materializing padded MLEs.

## Change Highlights

| Area | Change |
|------|--------|
| `sumcheck::frontload` | Separates local chunk rounds, worker-bit rounds, and true tail rounds using global MLE arity. |
| Worker-bit rounds | Uses `eq(z, worker_bit)` instead of treating exhausted local chunks as tail. |
| Product terms | Uses one shared `TermWorkerLayout` per product term, relying on the same-`num_vars` invariant. |
| Phase 2 | Collapses phase-1-exhausted `Normal` MLEs to constants; keeps live phase-2 `Normal` MLEs as worker MLEs. |
| Verifier oracle | Removes worker-aware evaluation from tests; checks against natural `frontload::evaluate`. |
| Tests | Ports PR #52 regressions and adds broad combinations of `Phase1Only`, exhausted `Normal`, and non-exhausted `Normal` cases. |

## Original Bug

The bug was not just an off-by-one tail boundary. The deeper issue was conflating two different concepts after a worker-local chunk exhausts:

| Round type | Correct meaning | Correct factor |
|------------|-----------------|----------------|
| Worker-bit canonical round | Real MLE variable stored in worker id | `eq(z, worker_bit)` |
| True frontload tail round | Variable missing from the compact MLE | `z` |

Using `z` for worker-bit canonical rounds makes the prover depend on worker layout and breaks the canonical verifier relation.

## Benchmark / Performance Impact

Sample size `10`; lower is better.

| Benchmark | Suffix mean | Frontload mean | Frontload speedup |
|-----------|------------:|---------------:|------------------:|
| `mixed_sum_nv_22_16_2` | 74.053 ms | 20.102 ms | 3.68x |
| `mixed_product_sum_nv_22_16_2` | 211.94 ms | 49.139 ms | 4.31x |

The same-`num_vars` refactor improved the frontload path compared with the previous canonical implementation:

| Benchmark | Before refactor | After refactor |
|-----------|----------------:|---------------:|
| `mixed_sum_nv_22_16_2/frontload` | 25.465 ms | 20.102 ms |
| `mixed_product_sum_nv_22_16_2/frontload` | 55.708 ms | 49.139 ms |

Command:

```sh
cargo bench -p sumcheck --bench devirgo_sumcheck -- 'mixed_sum_nv_22_16_2/(frontload_compact_a_plus_b_plus_c|suffix_phase2_a_plus_b_plus_c)|mixed_product_sum_nv_22_16_2/(frontload_compact_product_sum|suffix_phase2_product_sum)'
```

## Testing

| Command | Result |
|---------|--------|
| `cargo fmt --check` | Pass |
| `cargo test -p sumcheck` | Pass: `12 passed; 0 failed` |
| PR #52 tests before fix | Reproduced failure locally |
| `test_frontload_2phase_sum_keeps_small_mle_compact` | Pass |
| `test_random_monimials_use_frontload_sum` | Pass against canonical `frontload::evaluate` |
| `test_frontload_2phase_mle_category_combinations` | Pass for combinations of `Phase1Only`, exhausted `Normal`, and non-exhausted `Normal` |

## Risk / Rollout

| Risk | Mitigation |
|------|------------|
| Canonical verifier soundness | Tests now compare two-phase prover output against natural canonical `frontload::evaluate`, not worker-aware evaluation. |
| Product-term worker correlation | Regression suite covers category combinations and direct proof-round equality against single-worker frontload. |
| Same-`num_vars` invariant | The constructor already enforces it; the frontload path now asserts it explicitly before using the simplified layout. |
| Performance regression | Benchmarks cover mixed sum and mixed product frontload-vs-suffix cases. |
| Compatibility | Suffix prover remains available through `prove_suffix`. |

Rollback is to route affected callers back to `prove_suffix` or revert this PR.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.

- Perform review only; do not commit/push/propose code changes.
- Prefer inline comments on changed lines for each actionable finding.
- If inline comments are unavailable, use `[severity] path:line (symbol)` format.
- Prioritize soundness, performance, and architecture risks over style.
- Output order: findings by severity, then open questions, then brief summary.
- If PR description is empty or missing key context, report `PR metadata: description` as a finding.
