### PR TITLE
fix: handle partial-live frontload phase2 mles

### DIFF
--- a/crates/sumcheck/src/frontload.rs
+++ b/crates/sumcheck/src/frontload.rs
@@ -230,18 +230,25 @@ pub fn prove_2phase<'a, E: ExtensionField>(
     let (phase2_proof, phase2_state) =
         prove_inner(WorkingState::new(phase2_poly), transcript, false);
     proofs.extend(phase2_proof.proofs);
+    let challenges = workers
+        .first()
+        .map(|worker| worker.challenges.clone())
+        .unwrap_or_default()
+        .into_iter()
+        .chain(phase2_state.challenges)
+        .collect_vec();
+    let final_evaluations = normalize_phase2_final_evaluations(
+        phase2_state.final_evaluations,
+        &global_mle_num_vars,
+        local_num_vars,
+        &challenges,
+    );
 
     (
         IOPProof { proofs },
         FrontloadProverState {
-            challenges: workers
-                .first()
-                .map(|worker| worker.challenges.clone())
-                .unwrap_or_default()
-                .into_iter()
-                .chain(phase2_state.challenges)
-                .collect(),
-            final_evaluations: phase2_state.final_evaluations,
+            challenges,
+            final_evaluations,
         },
     )
 }
@@ -1122,6 +1129,28 @@ fn build_phase2_poly<'a, E: ExtensionField>(
     }
     poly.products = first_worker.poly.products.clone();
     poly
+}
+
+fn normalize_phase2_final_evaluations<E: ExtensionField>(
+    mut final_evaluations: Vec<Vec<E>>,
+    global_mle_num_vars: &[usize],
+    local_num_vars: usize,
+    challenges: &[Challenge<E>],
+) -> Vec<Vec<E>> {
+    final_evaluations
+        .iter_mut()
+        .zip_eq(global_mle_num_vars)
+        .for_each(|(evals, &global_num_vars)| {
+            if global_num_vars >= local_num_vars {
+                return;
+            }
+            let baked_tail = challenges[global_num_vars..local_num_vars]
+                .iter()
+                .fold(E::ONE, |acc, challenge| acc * challenge.elements);
+            let baked_tail_inv = baked_tail.inverse();
+            evals.iter_mut().for_each(|eval| *eval *= baked_tail_inv);
+        });
+    final_evaluations
 }
 
 fn read_eval<E: ExtensionField>(mle: &MultilinearExtension<'_, E>, idx: usize) -> E {

--- a/crates/sumcheck/src/frontload.rs
+++ b/crates/sumcheck/src/frontload.rs
@@ -303,23 +303,23 @@ pub fn claimed_sum<E: ExtensionField>(poly: &VirtualPolynomial<'_, E>) -> E {
     evaluations[0] + evaluations[1]
 }
 
-pub fn evaluate<E: ExtensionField>(poly: &VirtualPolynomial<'_, E>, point: &[E]) -> E {
+pub fn evaluate<E: ExtensionField>(
+    poly: &VirtualPolynomial<'_, E>,
+    point: &[E],
+    raw_mle_evals: &[E],
+) -> E {
     assert_eq!(poly.aux_info.max_num_variables, point.len());
+    assert_eq!(poly.flattened_ml_extensions.len(), raw_mle_evals.len());
     let mle_evals = poly
         .flattened_ml_extensions
         .iter()
-        .map(|mle| {
-            let local_eval = if mle.num_vars() == 0 {
-                read_eval(mle, 0)
-            } else {
-                mle.evaluate(&point[..mle.num_vars()])
-            };
+        .zip_eq(raw_mle_evals)
+        .map(|(mle, &raw_eval)| {
             point[mle.num_vars()..]
                 .iter()
-                .fold(local_eval, |acc, point| acc * *point)
+                .fold(raw_eval, |acc, point| acc * *point)
         })
         .collect_vec();
-
     poly.products
         .iter()
         .map(|MonomialTerms { terms }| {

--- a/crates/sumcheck/src/frontload.rs
+++ b/crates/sumcheck/src/frontload.rs
@@ -1074,7 +1074,15 @@ fn build_phase2_poly<'a, E: ExtensionField>(
         let global_num_vars = first_worker.global_mle_num_vars[mle_idx];
         let mle = match meta {
             FrontloadPolyMeta::Normal => {
-                if global_num_vars <= local_num_vars {
+                let remaining_num_vars = global_num_vars.saturating_sub(local_num_vars);
+                // At the phase boundary a split Normal MLE has three canonical cases:
+                // - exhausted in phase 1: all worker-bit variables were already bound, so sum
+                //   every worker scalar into one compact constant.
+                // - partially live in phase 2: some worker-bit variables were bound in phase 1
+                //   and the suffix remains live; aggregate workers with the same live suffix.
+                // - fully live in phase 2: no worker-bit variables were bound in phase 1, so keep
+                //   the full worker-index MLE.
+                if remaining_num_vars == 0 {
                     let value = workers
                         .iter()
                         .map(|worker| {
@@ -1083,6 +1091,16 @@ fn build_phase2_poly<'a, E: ExtensionField>(
                         })
                         .sum();
                     MultilinearExtension::from_evaluations_ext_vec(0, vec![value])
+                } else if remaining_num_vars < log_num_workers {
+                    let mut values = vec![E::ZERO; 1usize << remaining_num_vars];
+                    let bound_worker_bits = log_num_workers - remaining_num_vars;
+                    workers.iter().for_each(|worker| {
+                        let (worker_id, _) = worker.worker.expect("frontload worker missing");
+                        let phase2_idx = worker_id >> bound_worker_bits;
+                        values[phase2_idx] += read_eval(&worker.mles[mle_idx], 0)
+                            * worker.fixed_frontload_factor(mle_idx, local_num_vars);
+                    });
+                    MultilinearExtension::from_evaluations_ext_vec(remaining_num_vars, values)
                 } else {
                     let values = workers
                         .iter()

--- a/crates/sumcheck/src/test.rs
+++ b/crates/sumcheck/src/test.rs
@@ -63,9 +63,19 @@ fn test_frontload_mixed_size_sumcheck_helper<E: ExtensionField>() {
         .collect_vec();
 
     assert_eq!(
-        frontload::evaluate(&poly, &point),
+        frontload::evaluate(&poly, &point, &frontload_raw_mle_evals(&poly, &point)),
         subclaim.expected_evaluation
     );
+}
+
+fn frontload_raw_mle_evals<E: ExtensionField>(
+    poly: &VirtualPolynomial<'_, E>,
+    point: &[E],
+) -> Vec<E> {
+    poly.flattened_ml_extensions
+        .iter()
+        .map(|mle| mle.evaluate(&point[..mle.num_vars()]))
+        .collect_vec()
 }
 
 #[test]
@@ -155,7 +165,11 @@ fn test_frontload_2phase_sum_keeps_small_mle_compact() {
         .map(|challenge| challenge.elements)
         .collect_vec();
     assert_eq!(
-        frontload::evaluate(&direct_poly, &direct_point),
+        frontload::evaluate(
+            &direct_poly,
+            &direct_point,
+            &frontload_raw_mle_evals(&direct_poly, &direct_point),
+        ),
         direct_subclaim.expected_evaluation,
         "single frontload proof failed"
     );
@@ -166,7 +180,11 @@ fn test_frontload_2phase_sum_keeps_small_mle_compact() {
         );
     }
     assert_eq!(
-        frontload::evaluate(&direct_poly, &point),
+        frontload::evaluate(
+            &direct_poly,
+            &point,
+            &frontload_raw_mle_evals(&direct_poly, &point),
+        ),
         subclaim.expected_evaluation
     );
 }
@@ -204,7 +222,7 @@ fn test_frontload_small_only_sumcheck() {
         .map(|challenge| challenge.elements)
         .collect_vec();
     assert_eq!(
-        frontload::evaluate(&poly, &point),
+        frontload::evaluate(&poly, &point, &frontload_raw_mle_evals(&poly, &point)),
         subclaim.expected_evaluation
     );
 }
@@ -275,7 +293,11 @@ fn test_random_monimials_use_frontload_sum() {
         .map(|challenge| challenge.elements)
         .collect_vec();
     assert_eq!(
-        frontload::evaluate(&direct_poly, &point),
+        frontload::evaluate(
+            &direct_poly,
+            &point,
+            &frontload_raw_mle_evals(&direct_poly, &point),
+        ),
         subclaim.expected_evaluation,
         "frontload 2phase final evaluation mismatch: natural frontload evaluation \
          must agree with the verifier's expected evaluation"
@@ -377,7 +399,11 @@ fn test_frontload_2phase_mle_category_combinations() {
                 );
             }
             assert_eq!(
-                frontload::evaluate(&direct_poly, &point),
+                frontload::evaluate(
+                    &direct_poly,
+                    &point,
+                    &frontload_raw_mle_evals(&direct_poly, &point),
+                ),
                 subclaim.expected_evaluation,
                 "frontload 2phase failed for {selected_names}, \
                  log_num_workers={log_num_workers}"
@@ -395,6 +421,12 @@ fn test_frontload_2phase_mle_category_combinations() {
                      {selected_names}, log_num_workers={log_num_workers}"
                 );
             }
+            assert_eq!(
+                frontload::evaluate(&direct_poly, &point, &final_evals),
+                subclaim.expected_evaluation,
+                "frontload 2phase raw final evals should reconstruct subclaim expected \
+                 evaluation for {selected_names}, log_num_workers={log_num_workers}"
+            );
         }
     }
 }

--- a/crates/sumcheck/src/test.rs
+++ b/crates/sumcheck/src/test.rs
@@ -288,97 +288,133 @@ fn test_frontload_2phase_mle_category_combinations() {
         ("phase1_only", 2),
         ("normal_exhausted_with_tail", 3),
         ("normal_exhausted_at_phase1_end", 4),
+        ("normal_live_in_phase2_with_tail", 5),
         ("normal_not_exhausted", 6),
     ];
     let degree = 2;
     let max_num_variables = 6;
-    let num_threads = 4;
     let mut rng = StdRng::seed_from_u64(50);
 
-    for mask in 1usize..(1 << cases.len()) {
-        let selected = cases
-            .iter()
-            .enumerate()
-            .filter(|(idx, _)| ((mask >> idx) & 1) == 1)
-            .collect_vec();
-        let mut asserted_sum = GoldilocksExt2::ZERO;
-        let monomials = selected
-            .iter()
-            .map(|(_, (_, num_variables))| {
-                let (product, product_sum) =
-                    MultilinearExtension::random_mle_list(*num_variables, degree, &mut rng);
-                let scalar = GoldilocksExt2::random(&mut rng);
-                asserted_sum += product_sum * scalar;
-                Term { scalar, product }
-            })
-            .collect_vec();
-
-        let poly = VirtualPolynomials::<GoldilocksExt2>::new_from_monimials(
-            num_threads,
-            max_num_variables,
-            monomials
+    for log_num_workers in 0..=3 {
+        let num_threads = 1 << log_num_workers;
+        for mask in 1usize..(1 << cases.len()) {
+            let selected = cases
                 .iter()
-                .map(|Term { scalar, product }| Term {
-                    scalar: Either::Right(*scalar),
-                    product: product.iter().map(Either::Left).collect_vec(),
-                })
-                .collect_vec(),
-        );
-
-        let mut transcript =
-            BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
-        let (proof, _) = IOPProverState::<GoldilocksExt2>::prove(poly, &mut transcript);
-        let selected_names = selected.iter().map(|(_, (name, _))| *name).join(", ");
-        let mut transcript =
-            BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
-        let subclaim = IOPVerifierState::<GoldilocksExt2>::verify(
-            asserted_sum,
-            &proof,
-            &VPAuxInfo {
-                max_degree: degree,
-                max_num_variables,
-                ..Default::default()
-            },
-            &mut transcript,
-        );
-        let point = subclaim
-            .point
-            .iter()
-            .map(|challenge| challenge.elements)
-            .collect_vec();
-        let mut direct_poly = VirtualPolynomial::new(max_num_variables);
-        direct_poly.aux_info.max_degree = degree;
-        for Term { scalar, product } in &monomials {
-            let indices = product
-                .iter()
-                .map(|mle| direct_poly.register_mle(Arc::new(mle.clone())))
+                .enumerate()
+                .filter(|(idx, _)| ((mask >> idx) & 1) == 1)
                 .collect_vec();
-            direct_poly
-                .products
-                .push(multilinear_extensions::virtual_poly::MonomialTerms {
-                    terms: vec![Term {
+            let mut asserted_sum = GoldilocksExt2::ZERO;
+            let monomials = selected
+                .iter()
+                .map(|(_, (_, num_variables))| {
+                    let (product, product_sum) =
+                        MultilinearExtension::random_mle_list(*num_variables, degree, &mut rng);
+                    let scalar = GoldilocksExt2::random(&mut rng);
+                    asserted_sum += product_sum * scalar;
+                    Term { scalar, product }
+                })
+                .collect_vec();
+
+            let poly = VirtualPolynomials::<GoldilocksExt2>::new_from_monimials(
+                num_threads,
+                max_num_variables,
+                monomials
+                    .iter()
+                    .map(|Term { scalar, product }| Term {
                         scalar: Either::Right(*scalar),
-                        product: indices,
-                    }],
-                });
-        }
-        let mut direct_transcript =
-            BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
-        let (direct_proof, _) = frontload::prove(direct_poly.as_view(), &mut direct_transcript);
-        for (round, (direct, two_phase)) in
-            direct_proof.proofs.iter().zip(&proof.proofs).enumerate()
-        {
+                        product: product.iter().map(Either::Left).collect_vec(),
+                    })
+                    .collect_vec(),
+            );
+
+            let mut transcript =
+                BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
+            let (proof, _) = IOPProverState::<GoldilocksExt2>::prove(poly, &mut transcript);
+            let selected_names = selected.iter().map(|(_, (name, _))| *name).join(", ");
+            let mut transcript =
+                BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
+            let subclaim = IOPVerifierState::<GoldilocksExt2>::verify(
+                asserted_sum,
+                &proof,
+                &VPAuxInfo {
+                    max_degree: degree,
+                    max_num_variables,
+                    ..Default::default()
+                },
+                &mut transcript,
+            );
+            let point = subclaim
+                .point
+                .iter()
+                .map(|challenge| challenge.elements)
+                .collect_vec();
+            let mut direct_poly = VirtualPolynomial::new(max_num_variables);
+            direct_poly.aux_info.max_degree = degree;
+            for Term { scalar, product } in &monomials {
+                let indices = product
+                    .iter()
+                    .map(|mle| direct_poly.register_mle(Arc::new(mle.clone())))
+                    .collect_vec();
+                direct_poly
+                    .products
+                    .push(multilinear_extensions::virtual_poly::MonomialTerms {
+                        terms: vec![Term {
+                            scalar: Either::Right(*scalar),
+                            product: indices,
+                        }],
+                    });
+            }
+            let mut direct_transcript =
+                BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
+            let (direct_proof, _) = frontload::prove(direct_poly.as_view(), &mut direct_transcript);
+            for (round, (direct, two_phase)) in
+                direct_proof.proofs.iter().zip(&proof.proofs).enumerate()
+            {
+                assert_eq!(
+                    direct, two_phase,
+                    "frontload 2phase diverged at round {round} for {selected_names}, \
+                     log_num_workers={log_num_workers}"
+                );
+            }
             assert_eq!(
-                direct, two_phase,
-                "frontload 2phase diverged at round {round} for {selected_names}"
+                frontload::evaluate(&direct_poly, &point),
+                subclaim.expected_evaluation,
+                "frontload 2phase failed for {selected_names}, \
+                 log_num_workers={log_num_workers}"
             );
         }
-        assert_eq!(
-            frontload::evaluate(&direct_poly, &point),
-            subclaim.expected_evaluation,
-            "frontload 2phase failed for {selected_names}"
-        );
     }
+}
+
+#[test]
+fn test_frontload_2phase_exhausted_normal_final_eval_is_canonical() {
+    let max_num_variables = 6;
+    let mle_num_variables = 4;
+    let num_threads = 4;
+    let evals = (0..(1 << mle_num_variables))
+        .map(|idx| GoldilocksExt2::from_canonical_u64(idx as u64 + 1))
+        .collect_vec();
+    let mle = MultilinearExtension::from_evaluations_ext_vec(mle_num_variables, evals);
+    let poly = VirtualPolynomials::new_from_monimials(
+        num_threads,
+        max_num_variables,
+        vec![Term {
+            scalar: Either::Right(GoldilocksExt2::ONE),
+            product: vec![Either::Left(&mle)],
+        }],
+    );
+
+    let mut transcript = BasicTranscript::<GoldilocksExt2>::new(b"frontload-final-eval");
+    let (_proof, state) = IOPProverState::<GoldilocksExt2>::prove(poly, &mut transcript);
+    let point = state.collect_raw_challenges();
+    let final_evals = state.get_mle_flatten_final_evaluations();
+
+    assert_eq!(final_evals.len(), 1);
+    assert_eq!(
+        final_evals[0],
+        mle.evaluate(&point[..mle_num_variables]),
+        "exhausted Normal MLE final eval should be its canonical raw evaluation"
+    );
 }
 
 // test polynomial mixed with different num_var

--- a/crates/sumcheck/src/test.rs
+++ b/crates/sumcheck/src/test.rs
@@ -329,7 +329,7 @@ fn test_frontload_2phase_mle_category_combinations() {
 
             let mut transcript =
                 BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
-            let (proof, _) = IOPProverState::<GoldilocksExt2>::prove(poly, &mut transcript);
+            let (proof, state) = IOPProverState::<GoldilocksExt2>::prove(poly, &mut transcript);
             let selected_names = selected.iter().map(|(_, (name, _))| *name).join(", ");
             let mut transcript =
                 BasicTranscript::<GoldilocksExt2>::new(b"frontload-category-combinations");
@@ -382,39 +382,21 @@ fn test_frontload_2phase_mle_category_combinations() {
                 "frontload 2phase failed for {selected_names}, \
                  log_num_workers={log_num_workers}"
             );
+            let final_evals = state.get_mle_flatten_final_evaluations();
+            assert_eq!(final_evals.len(), monomials.len() * degree);
+            for (actual, mle) in final_evals
+                .iter()
+                .zip_eq(monomials.iter().flat_map(|term| &term.product))
+            {
+                assert_eq!(
+                    *actual,
+                    mle.evaluate(&point[..mle.num_vars()]),
+                    "frontload 2phase final eval should be canonical raw MLE opening for \
+                     {selected_names}, log_num_workers={log_num_workers}"
+                );
+            }
         }
     }
-}
-
-#[test]
-fn test_frontload_2phase_exhausted_normal_final_eval_is_canonical() {
-    let max_num_variables = 6;
-    let mle_num_variables = 4;
-    let num_threads = 4;
-    let evals = (0..(1 << mle_num_variables))
-        .map(|idx| GoldilocksExt2::from_canonical_u64(idx as u64 + 1))
-        .collect_vec();
-    let mle = MultilinearExtension::from_evaluations_ext_vec(mle_num_variables, evals);
-    let poly = VirtualPolynomials::new_from_monimials(
-        num_threads,
-        max_num_variables,
-        vec![Term {
-            scalar: Either::Right(GoldilocksExt2::ONE),
-            product: vec![Either::Left(&mle)],
-        }],
-    );
-
-    let mut transcript = BasicTranscript::<GoldilocksExt2>::new(b"frontload-final-eval");
-    let (_proof, state) = IOPProverState::<GoldilocksExt2>::prove(poly, &mut transcript);
-    let point = state.collect_raw_challenges();
-    let final_evals = state.get_mle_flatten_final_evaluations();
-
-    assert_eq!(final_evals.len(), 1);
-    assert_eq!(
-        final_evals[0],
-        mle.evaluate(&point[..mle_num_variables]),
-        "exhausted Normal MLE final eval should be its canonical raw evaluation"
-    );
 }
 
 // test polynomial mixed with different num_var


### PR DESCRIPTION
## Problem

Frontload two-phase sumcheck still missed one valid `Normal` MLE shape:

```text
N = global num vars
w = log2(num_workers)
L = N - w
k = MLE canonical num vars
```

The previous implementation handled:

| Case | Condition | Phase-2 shape |
|------|-----------|---------------|
| Exhausted in phase 1 | `k <= L` | compact constant |
| Fully live in phase 2 | `k == N` | full worker-index MLE |

It did not handle the middle case:

```text
L < k < N
```

Example from the regression:

```text
N = 6, w = 2, L = 4, k = 5
phase 1 vars: x0..x3
phase 2 vars: x4,x5
local chunk vars: x0..x2
worker-bit canonical vars: x3,x4
true tail vars: x5
```

Here one worker-bit canonical variable is already bound in phase 1 (`x3`), while one remains live in phase 2 (`x4`). Treating this as either fully exhausted or fully live produces incorrect phase-2 polynomial construction.

A related API issue was that frontload two-phase final evaluations could expose proof-internal tail factors. Consumers such as Ceno expect raw canonical MLE openings:

```text
mle(r0..r{k-1})
```

not:

```text
mle(r0..r{k-1}) * product(r{k}..r{phase1_end-1})
```

## Approach

Keep the full `2^w` worker split, and encapsulate the partial-live logic only in `build_phase2_poly`.

At the phase boundary each worker has a folded scalar:

```text
s_b = e_b(bound local vars) * bound_eq_for_phase1_worker_bits * phase1_tail
```

`build_phase2_poly` now handles three canonical cases:

| Case | Condition | Construction |
|------|-----------|--------------|
| Exhausted | `k <= L` | `phase2_mle[0] = sum_b s_b` |
| Partial-live | `L < k < N` | aggregate workers with the same live phase-2 suffix |
| Fully live | `k == N` | `phase2_mle[b] = s_b` |

For the partial-live case:

```text
remaining = k - L          // live canonical phase-2 worker bits
bound = w - remaining      // worker bits already bound in phase 1
worker_id = (bound_prefix, live_suffix)

phase2_mle[live_suffix] = sum_bound_prefix s_{bound_prefix, live_suffix}
```

Then normal frontload phase 2 evaluates:

```text
phase2_mle(x_L..x{k-1}) * product_{i=k}^{N-1} x_i
```

So the verifier remains canonical:

```text
e(x0..x{k-1}) * product_{i=k}^{N-1} x_i
```

No verifier-side knowledge of worker layout is introduced.

## Side Note: Raw Final-Eval Contract

`get_mle_flatten_final_evaluations()` now exposes raw canonical MLE openings for frontload:

```text
mle(r0..r{k-1})
```

It excludes all true frontload tail factors. This lets consumers reconstruct the sumcheck subclaim with the same canonical frontload tail rule used by the verifier.

Implementation details:

- Proof construction remains unchanged.
- After phase 2, frontload normalizes final evaluations by dividing out baked phase-1 true tail factors for `k < L`.
- This intentionally assumes Fiat-Shamir challenges are nonzero, matching the protocol assumption used elsewhere in this codebase.
- The old `frontload::evaluate(poly, point)` helper was removed to avoid hiding raw-vs-tail behavior.
- `frontload::evaluate(poly, point, raw_mle_evals)` now explicitly reconstructs the full canonical frontload polynomial from raw MLE openings plus tail factors.

## Testing

| Command | Result |
|---------|--------|
| `cargo fmt --check` | Pass |
| `cargo test -p sumcheck` | Pass: `12 passed; 0 failed` |
| `cargo test -p sumcheck --lib -- test_frontload_2phase_mle_category_combinations --nocapture` | Pass |

Regression coverage:

- Adds `normal_live_in_phase2_with_tail` (`k=5` when `N=6`) to `test_frontload_2phase_mle_category_combinations`.
- Runs category combinations across `log_num_workers = 0..=3`, i.e. `num_threads = 1,2,4,8`.
- Keeps direct proof-round equality checks against single-worker canonical frontload.
- Verifies frontload final evals equal raw canonical MLE openings.
- Verifies `frontload::evaluate(poly, point, raw_mle_evals)` reconstructs `subclaim.expected_evaluation` from those raw openings.

## Benchmark / Performance Impact

Command:

```sh
cargo bench -p sumcheck --bench devirgo_sumcheck -- 'mixed_sum_nv_22_16_2/(frontload_compact_a_plus_b_plus_c|suffix_phase2_a_plus_b_plus_c)|mixed_product_sum_nv_22_16_2/(frontload_compact_product_sum|suffix_phase2_product_sum)'
```

Before = previous local refactor commit `6c74b7d`.
After = partial-live fix commit `83d0108` / current PR branch state with the same proof-generation path.

| Benchmark | Before | After | Delta |
|-----------|-------:|------:|------:|
| `mixed_sum_nv_22_16_2/frontload` | 20.102 ms | 18.529 ms | 1.08x faster |
| `mixed_product_sum_nv_22_16_2/frontload` | 49.139 ms | 58.403 ms | 1.19x slower |

Current frontload vs suffix:

| Benchmark | Suffix mean | Frontload mean | Frontload speedup |
|-----------|------------:|---------------:|------------------:|
| `mixed_sum_nv_22_16_2` | 72.132 ms | 18.529 ms | 3.89x |
| `mixed_product_sum_nv_22_16_2` | 223.23 ms | 58.403 ms | 3.82x |

The final-eval normalization/API change is postprocessing and does not alter proof round construction. Frontload remains faster than suffix in the measured mixed sum/product cases.

## Risk / Rollout

| Risk | Mitigation |
|------|------------|
| Partial-live `Normal` soundness | New `normal_live_in_phase2_with_tail` regression covers `L < k < N`. |
| Worker-count edge cases | Category combinations now run for `num_threads = 1,2,4,8`. |
| Canonical verifier relation | Tests compare two-phase proof rounds and final evaluation against canonical single-worker frontload. |
| Raw final-eval contract | Tests verify final evals are raw MLE openings and reconstruct `subclaim.expected_evaluation` only after applying canonical tails. |
| Performance regression | Benchmarks reported above; frontload remains faster than suffix in measured mixed sum/product cases. |
| Compatibility | Suffix prover remains available through `prove_suffix`. |

Rollback is to route affected callers back to `prove_suffix` or revert this PR.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.

- Perform review only; do not commit/push/propose code changes.
- Prefer inline comments on changed lines for each actionable finding.
- If inline comments are unavailable, use `[severity] path:line (symbol)` format.
- Prioritize soundness, performance, and architecture risks over style.
- Output order: findings by severity, then open questions, then brief summary.
- If PR description is empty or missing key context, report `PR metadata: description` as a finding.
