### PR TITLE
Optimize frontload worker-bit merge evaluation

### DIFF
--- a/crates/sumcheck/src/frontload.rs
+++ b/crates/sumcheck/src/frontload.rs
@@ -191,7 +191,7 @@ pub fn prove_2phase<'a, E: ExtensionField>(
         });
         let mut evaluations = if workers
             .first()
-            .is_some_and(|worker| worker.any_mle_round_needs_canonical_merge(round))
+            .is_some_and(|worker| worker.any_mle_round_needs_worker_bit_merge(round))
         {
             round_evaluations_across_workers(&workers, round, max_degree)
         } else {
@@ -445,6 +445,20 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
         evaluations
     }
 
+    fn round_without_worker_bit_merge_evaluations(&self, round: usize) -> Vec<E> {
+        let mut evaluations = vec![E::ZERO; self.poly.aux_info.max_degree + 1];
+        for (MonomialTerms { terms }, metadata) in
+            self.poly.products.iter().zip_eq(&self.term_metadata)
+        {
+            for (term, metadata) in terms.iter().zip_eq(metadata) {
+                if !self.term_needs_worker_bit_merge(term, round) {
+                    self.add_term_round_evaluations(term, *metadata, round, &mut evaluations);
+                }
+            }
+        }
+        evaluations
+    }
+
     fn add_term_round_evaluations(
         &self,
         term: &Term<either::Either<E::BaseField, E>, usize>,
@@ -453,15 +467,51 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
         acc: &mut [E],
     ) {
         debug_assert_eq!(metadata.degree, term.product.len());
+        if !self.worker_matches_frontload_tail(term) {
+            return;
+        }
+
+        if self.add_same_height_no_worker_bits(term, metadata, round, acc) {
+            return;
+        }
+
         if metadata.all_same_local_num_vars
             && metadata.all_same_global_num_vars
             && metadata.local_num_vars == self.poly.aux_info.max_num_variables
             && self.uniform_term_has_no_frontload_tail(metadata)
         {
+            macro_rules! add_uniform {
+                ($degree:literal) => {{
+                    let live_vars = metadata.local_num_vars.saturating_sub(round);
+                    let lane_count = if live_vars == 0 {
+                        1
+                    } else {
+                        1usize << (live_vars - 1)
+                    };
+                    let suffix_mask = uniform_suffix_mask(metadata.local_num_vars, round);
+                    sumcheck_macro::frontload_uniform_sumcheck_code_gen!(
+                        $degree,
+                        |i: usize| self.mles[term.product[i]].evaluations(),
+                        metadata.local_num_vars,
+                        round,
+                        lane_count,
+                        suffix_mask
+                    );
+                }};
+            }
             match metadata.degree {
-                2 if self.add_uniform_degree2(term, metadata, round, acc) => return,
-                3 if self.add_uniform_degree3(term, metadata, round, acc) => return,
-                4 if self.add_uniform_degree4(term, metadata, round, acc) => return,
+                2 => {
+                    add_uniform!(2);
+                    return;
+                }
+                3 => {
+                    add_uniform!(3);
+                    return;
+                }
+                4 => {
+                    add_uniform!(4);
+                    return;
+                }
                 _ => {}
             }
         }
@@ -470,6 +520,68 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
         acc.iter_mut().zip_eq(evaluations).for_each(|(acc, eval)| {
             *acc += eval;
         });
+    }
+
+    fn add_same_height_no_worker_bits(
+        &self,
+        term: &Term<either::Either<E::BaseField, E>, usize>,
+        metadata: TermMetadata,
+        round: usize,
+        acc: &mut [E],
+    ) -> bool {
+        if !metadata.all_same_local_num_vars
+            || !metadata.all_same_global_num_vars
+            || term
+                .product
+                .iter()
+                .any(|&idx| self.mle_has_worker_bits[idx])
+        {
+            return false;
+        }
+
+        if round < metadata.local_num_vars {
+            macro_rules! add_uniform {
+                ($degree:literal) => {{
+                    let live_vars = metadata.local_num_vars.saturating_sub(round);
+                    let lane_count = if live_vars == 0 {
+                        1
+                    } else {
+                        1usize << (live_vars - 1)
+                    };
+                    let suffix_mask = uniform_suffix_mask(metadata.local_num_vars, round);
+                    sumcheck_macro::frontload_uniform_sumcheck_code_gen!(
+                        $degree,
+                        |i: usize| self.mles[term.product[i]].evaluations(),
+                        metadata.local_num_vars,
+                        round,
+                        lane_count,
+                        suffix_mask
+                    );
+                }};
+            }
+            match metadata.degree {
+                1 => add_uniform!(1),
+                2 => add_uniform!(2),
+                3 => add_uniform!(3),
+                4 => add_uniform!(4),
+                5 => add_uniform!(5),
+                _ => return false,
+            }
+            return true;
+        }
+
+        let product = term
+            .product
+            .iter()
+            .map(|&idx| read_eval(&self.mles[idx], 0) * self.fixed_frontload_factor(idx, round))
+            .product::<E>();
+        let degree = metadata.degree;
+        let evals = (0..=degree).map(|eval_idx| {
+            let z = E::from_canonical_u64(eval_idx as u64);
+            product * (0..degree).map(|_| z).product::<E>()
+        });
+        self.add_evaluations(acc, degree, scalar_to_ext(&term.scalar), evals);
+        true
     }
 
     #[inline]
@@ -540,90 +652,12 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
         });
     }
 
-    fn add_uniform_degree2(
-        &self,
-        term: &Term<either::Either<E::BaseField, E>, usize>,
-        metadata: TermMetadata,
-        round: usize,
-        acc: &mut [E],
-    ) -> bool {
-        let live_vars = metadata.local_num_vars.saturating_sub(round);
-        let lane_count = if live_vars == 0 {
-            1
-        } else {
-            1usize << (live_vars - 1)
-        };
-        let suffix_mask = uniform_suffix_mask(metadata.local_num_vars, round);
-        sumcheck_macro::frontload_uniform_sumcheck_code_gen!(
-            2,
-            |i: usize| self.mles[term.product[i]].evaluations(),
-            metadata.local_num_vars,
-            round,
-            lane_count,
-            suffix_mask
-        );
-        true
-    }
-
-    fn add_uniform_degree3(
-        &self,
-        term: &Term<either::Either<E::BaseField, E>, usize>,
-        metadata: TermMetadata,
-        round: usize,
-        acc: &mut [E],
-    ) -> bool {
-        let live_vars = metadata.local_num_vars.saturating_sub(round);
-        let lane_count = if live_vars == 0 {
-            1
-        } else {
-            1usize << (live_vars - 1)
-        };
-        let suffix_mask = uniform_suffix_mask(metadata.local_num_vars, round);
-        sumcheck_macro::frontload_uniform_sumcheck_code_gen!(
-            3,
-            |i: usize| self.mles[term.product[i]].evaluations(),
-            metadata.local_num_vars,
-            round,
-            lane_count,
-            suffix_mask
-        );
-        true
-    }
-
-    fn add_uniform_degree4(
-        &self,
-        term: &Term<either::Either<E::BaseField, E>, usize>,
-        metadata: TermMetadata,
-        round: usize,
-        acc: &mut [E],
-    ) -> bool {
-        let live_vars = metadata.local_num_vars.saturating_sub(round);
-        let lane_count = if live_vars == 0 {
-            1
-        } else {
-            1usize << (live_vars - 1)
-        };
-        let suffix_mask = uniform_suffix_mask(metadata.local_num_vars, round);
-        sumcheck_macro::frontload_uniform_sumcheck_code_gen!(
-            4,
-            |i: usize| self.mles[term.product[i]].evaluations(),
-            metadata.local_num_vars,
-            round,
-            lane_count,
-            suffix_mask
-        );
-        true
-    }
-
     fn term_round_evaluations(
         &self,
         term: &Term<either::Either<E::BaseField, E>, usize>,
         round: usize,
     ) -> Vec<E> {
         let degree = term.product.len();
-        if !self.worker_matches_frontload_tail(term) {
-            return vec![E::ZERO; self.poly.aux_info.max_degree + 1];
-        }
         let has_worker_bit_round = term
             .product
             .iter()
@@ -722,7 +756,9 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
         {
             return true;
         }
-        worker_id == (1usize << log_num_workers) - 1
+        let worker_mask = (1usize << log_num_workers) - 1;
+        let owner = term.product.iter().fold(0usize, |acc, &idx| acc ^ idx) & worker_mask;
+        worker_id == owner
     }
 
     fn required_future_frontload_mask(
@@ -831,9 +867,21 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
             .unwrap_or(1)
     }
 
-    fn any_mle_round_needs_canonical_merge(&self, round: usize) -> bool {
+    fn any_mle_round_needs_worker_bit_merge(&self, round: usize) -> bool {
         self.worker.is_some()
             && (0..self.mles.len()).any(|mle_idx| {
+                self.mle_has_worker_bits[mle_idx]
+                    && round >= self.poly.flattened_ml_extensions[mle_idx].num_vars()
+            })
+    }
+
+    fn term_needs_worker_bit_merge(
+        &self,
+        term: &Term<either::Either<E::BaseField, E>, usize>,
+        round: usize,
+    ) -> bool {
+        self.worker.is_some()
+            && term.product.iter().any(|&mle_idx| {
                 self.mle_has_worker_bits[mle_idx]
                     && round >= self.poly.flattened_ml_extensions[mle_idx].num_vars()
             })
@@ -849,7 +897,7 @@ impl<'a, E: ExtensionField> WorkingState<'a, E> {
                 assert!(
                     rest.iter()
                         .all(|&idx| self.global_mle_num_vars[idx] == first_num_vars),
-                    "frontload 2phase expects every MLE in a product term to have the same canonical num_vars"
+                    "frontload 2phase expects every MLE in a product term to have the same global num_vars"
                 );
             }
         }
@@ -889,17 +937,44 @@ fn round_evaluations_across_workers<'a, E: ExtensionField>(
     max_degree: usize,
 ) -> Vec<E> {
     let first_worker = workers.first().expect("frontload 2phase needs workers");
-    let mut evaluations = vec![E::ZERO; max_degree + 1];
-    for MonomialTerms { terms } in &first_worker.poly.products {
-        for term in terms {
-            let term_evaluations = term_round_evaluations_across_workers(workers, term, round);
-            evaluations
-                .iter_mut()
-                .zip_eq(term_evaluations)
-                .for_each(|(acc, eval)| *acc += eval);
-        }
-    }
-    evaluations
+    let no_worker_bit_merge_evaluations = workers
+        .par_iter()
+        .map(|worker| worker.round_without_worker_bit_merge_evaluations(round))
+        .reduce(
+            || vec![E::ZERO; max_degree + 1],
+            |mut acc, evals| {
+                acc.iter_mut()
+                    .zip_eq(evals)
+                    .for_each(|(acc, eval)| *acc += eval);
+                acc
+            },
+        );
+
+    let worker_bit_merge_evaluations = first_worker
+        .poly
+        .products
+        .iter()
+        .zip_eq(&first_worker.term_metadata)
+        .flat_map(|(MonomialTerms { terms }, metadata)| terms.iter().zip_eq(metadata))
+        .filter(|(term, _metadata)| first_worker.term_needs_worker_bit_merge(term, round))
+        .collect_vec()
+        .into_par_iter()
+        .map(|(term, _metadata)| term_round_evaluations_across_workers(workers, term, round))
+        .reduce(
+            || vec![E::ZERO; max_degree + 1],
+            |mut acc, evals| {
+                acc.iter_mut()
+                    .zip_eq(evals)
+                    .for_each(|(acc, eval)| *acc += eval);
+                acc
+            },
+        );
+
+    no_worker_bit_merge_evaluations
+        .into_iter()
+        .zip_eq(worker_bit_merge_evaluations)
+        .map(|(left, right)| left + right)
+        .collect()
 }
 
 fn term_round_evaluations_across_workers<'a, E: ExtensionField>(
@@ -934,7 +1009,7 @@ fn term_round_evaluations_across_workers<'a, E: ExtensionField>(
                     .product
                     .iter()
                     .map(|&idx| {
-                        canonical_worker_group_value(
+                        frontload_tail_worker_group_value(
                             workers, layout, idx, round, lane, z, group_key,
                         )
                     })
@@ -1011,7 +1086,7 @@ impl TermWorkerLayout {
     }
 }
 
-fn canonical_worker_group_value<'a, E: ExtensionField>(
+fn frontload_tail_worker_group_value<'a, E: ExtensionField>(
     workers: &[WorkingState<'a, E>],
     layout: TermWorkerLayout,
     mle_idx: usize,
@@ -1082,7 +1157,7 @@ fn build_phase2_poly<'a, E: ExtensionField>(
         let mle = match meta {
             FrontloadPolyMeta::Normal => {
                 let remaining_num_vars = global_num_vars.saturating_sub(local_num_vars);
-                // At the phase boundary a split Normal MLE has three canonical cases:
+                // At the phase boundary a split Normal MLE has three frontload-tail cases:
                 // - exhausted in phase 1: all worker-bit variables were already bound, so sum
                 //   every worker scalar into one compact constant.
                 // - partially live in phase 2: some worker-bit variables were bound in phase 1


### PR DESCRIPTION
## Problem

frontload sumcheck might (in particular in Ceno) mix short / Phase1Only terms with split Normal terms. The previous round-level check was too broad: if any MLE in the round needed worker-bit/frontload-tail merge, every term in that round used the across-worker merge path.

Concrete shape:

```text
P = T1 + T2
T1 = a * b      // a,b are Phase1Only: no worker-bit data
T2 = c * d      // c,d are split Normal MLEs: worker-bit tail exists
```

Within one product term, frontload requires product MLEs to have the same global height, so `c` and `d` reach the worker-bit tail together. At that round, `T1` does not need worker-bit merge while `T2` does. The old behavior evaluated both through the across-worker merge path; this PR keeps `T1` on the normal per-worker path and only sends `T2` through worker-bit/frontload-tail merge.

## Approach

- Make worker-bit merge term-local instead of round-global.
- Keep terms without active worker-bit data on the normal parallel worker path.
- Send only terms with active split Normal MLEs through across-worker frontload-tail grouping.
- Rename local helpers from canonical wording to worker-bit/frontload-tail terminology.
- Remove degree-specific uniform helper boilerplate and reuse `frontload_uniform_sumcheck_code_gen!` through local `add_uniform!` wrappers.

## Testing

- `cargo fmt`
- `cargo check -p sumcheck --benches`
- `GKR_CENO_BENCH_SAMPLES=10 cargo bench -p sumcheck --bench ceno_batched_main -- --save-baseline previous` on the previous commit
- `GKR_CENO_BENCH_SAMPLES=10 cargo bench -p sumcheck --bench ceno_batched_main -- frontload --baseline previous` on this PR
- `GKR_CENO_BENCH_SAMPLES=10 cargo bench -p sumcheck --bench devirgo_sumcheck -- 'ceno_dense_uniform_.*/frontload' --save-baseline previous` on the previous commit
- `GKR_CENO_BENCH_SAMPLES=10 cargo bench -p sumcheck --bench devirgo_sumcheck -- 'ceno_dense_uniform_.*/frontload' --baseline previous` on this PR

`ceno_batched_main/default/max_vars_20/mles_52/terms_150`:

| Mode | Previous | This PR | Change |
|---|---:|---:|---:|
| `frontload` | `1.2466 s` | `1.1411 s` | `+8.47% faster` |
| `suffix_legacy` | `9.0554 s` | `9.1238 s` | no significant change (`p = 0.17`) |

Frontload Criterion interval: `[-10.601%, -8.4702%, -6.6314%]`, `p < 0.05`.

Additional completed benches from `devirgo_sumcheck`, excluding `ceno_batched_main`:

| Bench | Previous | This PR | Change |
|---|---:|---:|---:|
| `ceno_dense_uniform_keccak_tower_nv_11_mles_4705_terms_3475/frontload` | `121.42 ms` | `130.86 ms` | `7.78%` slower, `p = 0.02` |
| `ceno_dense_uniform_keccak_main_nv_12_mles_1700_terms_2785/frontload` | `228.53 ms` | `210.12 ms` | `8.06%` faster, `p < 0.05` |
| `ceno_dense_uniform_weierstrass_main_nv_10_mles_2193_terms_5297/frontload` | `166.79 ms` | `156.30 ms` | `6.29%` faster, `p < 0.05` |
| `ceno_dense_uniform_shard_ram_main_nv_13_mles_382_terms_992/frontload` | `95.407 ms` | `92.838 ms` | `2.76%` faster, `p < 0.05` |

## Risk / Rollout

Soundness risk is limited to frontload worker-bit rounds. The proof structure and transcript order are unchanged; this only decides which terms use normal per-worker reduction versus existing across-worker merge. Rollback is a single commit revert if a larger CENO shape exposes a missed worker-bit merge case.

The dense uniform bench coverage shows the optimization is shape-sensitive: three CENO-like shapes improve, while the Keccak tower shape regresses by `7.78%`. That regression is acceptable for this PR only if the batched-main target remains the priority workload; otherwise this should be revisited before rollout.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.

- Perform review only; do not commit/push/propose code changes.
- Prefer inline comments on changed lines for each actionable finding.
- If inline comments are unavailable, use `[severity] path:line (symbol)` format.
- Prioritize soundness, performance, and architecture risks over style.
- Output order: findings by severity, then open questions, then brief summary.
- If PR description is empty or missing key context, report `PR metadata: description` as a finding.
