### PR TITLE
ci: add sumcheck performance regression guard

### DIFF
--- a/.github/scripts/check-criterion-regression.sh
+++ b/.github/scripts/check-criterion-regression.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_sha="${1:?base sha is required}"
+head_sha="${2:?head sha is required}"
+
+bench="${GKR_PERF_BENCH:-ceno_batched_main}"
+baseline="${GKR_PERF_BASELINE:-ci-main}"
+noise_threshold="${GKR_PERF_NOISE_THRESHOLD:-0.15}"
+output_file="${RUNNER_TEMP:-/tmp}/criterion-${bench}-comparison.log"
+
+export RUST_MIN_STACK="${RUST_MIN_STACK:-33554432}"
+export GKR_CENO_BENCH_SCALE="${GKR_CENO_BENCH_SCALE:-tiny}"
+export GKR_CENO_BENCH_SAMPLES="${GKR_CENO_BENCH_SAMPLES:-10}"
+
+fetch_commit() {
+  local remote_url="$1"
+  local sha="$2"
+
+  if git rev-parse --verify --quiet "${sha}^{commit}" >/dev/null; then
+    return
+  fi
+
+  git fetch --no-tags --depth=1 "$remote_url" "$sha"
+}
+
+if [[ -n "${BASE_REPO_URL:-}" ]]; then
+  fetch_commit "$BASE_REPO_URL" "$base_sha"
+fi
+
+if [[ -n "${HEAD_REPO_URL:-}" ]]; then
+  fetch_commit "$HEAD_REPO_URL" "$head_sha"
+fi
+
+git checkout --detach "$base_sha"
+cargo bench -p sumcheck --bench "$bench" -- --save-baseline "$baseline"
+
+git checkout --detach "$head_sha"
+cargo bench -p sumcheck --bench "$bench" -- \
+  --baseline "$baseline" \
+  --noise-threshold "$noise_threshold" \
+  | tee "$output_file"
+
+if grep -q "Performance has regressed" "$output_file"; then
+  echo "::error::Criterion reported a sumcheck performance regression."
+  awk '
+    /^Benchmarking / { benchmark = $0 }
+    /^[[:space:]]*change:/ { change = $0 }
+    /Performance has regressed/ {
+      print benchmark
+      print change
+      print $0
+      print ""
+    }
+  ' "$output_file"
+  exit 1
+fi
+
+echo "No Criterion performance regression detected for ${bench}."

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -1,0 +1,64 @@
+name: Performance Regression
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - ".github/scripts/check-criterion-regression.sh"
+      - ".github/workflows/perf-regression.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/ff_ext/**"
+      - "crates/multilinear_extensions/**"
+      - "crates/p3/**"
+      - "crates/sumcheck/**"
+      - "crates/transcript/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sumcheck:
+    name: Sumcheck Criterion Guard
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-08-18
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: perf-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: perf-${{ runner.os }}-cargo-
+
+      - name: Check sumcheck performance regression
+        env:
+          BASE_REPO_URL: https://x-access-token:${{ github.token }}@github.com/${{ github.event.pull_request.base.repo.full_name }}.git
+          HEAD_REPO_URL: https://x-access-token:${{ github.token }}@github.com/${{ github.event.pull_request.head.repo.full_name }}.git
+          CARGO_INCREMENTAL: "0"
+          GKR_CENO_BENCH_SAMPLES: "10"
+          GKR_CENO_BENCH_SCALE: tiny
+          GKR_PERF_NOISE_THRESHOLD: "0.15"
+          RAYON_NUM_THREADS: "2"
+          RUST_MIN_STACK: "33554432"
+        run: |
+          bash .github/scripts/check-criterion-regression.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -5,16 +5,6 @@ on:
     branches:
       - main
     types: [synchronize, opened, reopened, ready_for_review]
-    paths:
-      - ".github/scripts/check-criterion-regression.sh"
-      - ".github/workflows/perf-regression.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/ff_ext/**"
-      - "crates/multilinear_extensions/**"
-      - "crates/p3/**"
-      - "crates/sumcheck/**"
-      - "crates/transcript/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -2,6 +2,8 @@ name: Performance Regression
 
 on:
   pull_request:
+    branches:
+      - main
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/scripts/check-criterion-regression.sh"


### PR DESCRIPTION
## Problem

Sumcheck performance regressions are currently detectable only by manually running Criterion benches.

## Approach

Add a PR-only GitHub Actions guard for PRs targeting `main`. The workflow compares the PR base SHA against the head SHA with the `sumcheck` `ceno_batched_main` Criterion bench on `tiny` scale and fails when Criterion reports a regression beyond the configured noise threshold.

## Testing

- `bash -n .github/scripts/check-criterion-regression.sh`
- Parsed `.github/workflows/perf-regression.yml` as YAML.
- Ran the guard locally against the same `origin/main` SHA; it reported no Criterion regression.

## Risk / Rollout

Main risk is CI noise from benchmark variance. The guard uses a small deterministic benchmark, fixed Rayon thread count, and a 15% noise threshold; roll back by disabling or reverting the workflow if it proves flaky.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.

- Perform review only; do not commit/push/propose code changes.
- Prefer inline comments on changed lines for each actionable finding.
- If inline comments are unavailable, use `[severity] path:line (symbol)` format.
- Prioritize soundness, performance, and architecture risks over style.
- Output order: findings by severity, then open questions, then brief summary.
- If PR description is empty or missing key context, report `PR metadata: description` as a finding.